### PR TITLE
chore: Upload artifacts from Github CI

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -21,9 +21,14 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
-
-      - name: Run tests
-        run: ./gradlew check
-        env:
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Run tests
+        run: ./gradlew check --no-daemon
+
+
+      - name: Publish Snapshot artifact
+        run: ./gradlew publish --no-daemon

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,7 +1,13 @@
 name: Publish release SDK to the Maven Central Repository
+
 on:
   release:
     types: [published]
+
+env:
+  ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+  ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -14,8 +20,6 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           server-id: ossrh
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -24,3 +28,6 @@ jobs:
 
       - name: Publish to Maven Central
         run: ./gradlew publish --no-daemon
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -14,24 +14,13 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Download test data
         run: make test-data
 
-      - name: Publish package with debug logging
-        run: mvn --batch-mode deploy -X
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Release the staging repository
-        run: mvn nexus-staging:release -X
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Publish to Maven Central
+        run: ./gradlew publish --no-daemon

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,4 +1,4 @@
-name: Publish sdk to the Maven Central Repository
+name: Publish release SDK to the Maven Central Repository
 on:
   release:
     types: [published]

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,4 +1,4 @@
-name: Publish snapshot SDK to the oss.sonatype.org
+name: Publish SDK Snapshot artifact
 
 on:
   pull_request:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,28 +2,23 @@ name: Publish snapshot SDK to the oss.sonatype.org
 
 on:
   pull_request:
-    paths:
-      - '**/*'
 
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
 
 jobs:
-  lint-test-sdk:
+  publish-snapshot:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java-version: 17
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: 17
           distribution: 'adopt'
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Publish Snapshot artifact
         run: ./gradlew publish --no-daemon
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,4 +1,4 @@
-name: Test and lint
+name: Publish snapshot SDK to the oss.sonatype.org
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['8', '11', '17'] # Define the Java versions to test against
+        java-version: 17
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,5 +28,5 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Run tests
-        run: ./gradlew check --no-daemon
+      - name: Publish Snapshot artifact
+        run: ./gradlew publish --no-daemon

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,7 +1,8 @@
 name: Publish SDK Snapshot artifact
 
 on:
-  pull_request:
+  push:
+    branches: [main]
 
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,38 @@
 # Eppo JVM common SDK
 
-This is the common SDK for the Eppo JVM. It provides a set of classes and interfaces that are used by the Eppo JVM to 
-interact with the Eppo API.
+This is the common SDK for the Eppo JVM SDKs. It provides a set of classes and interfaces that are used by the SDKs to
+interact with the Eppo API. You should probably not use this library directly and instead use the [Android](https://github.com/Eppo-exp/android-sdk)
+or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
+
+# Usage
+
+## build.gradle:
+
+```groovy
+dependencies {
+  implementation 'com.eppo:eppo-jvm-common-sdk:1.0.0'
+}
+```
+
+# Releasing a new version
+
+Bump the project version in `build.gradle`
+To release a new version of the SDK, you need to create a new tag in the repository. The tag should be named `vX.Y.Z`,
+where `X.Y.Z` is the version number of the release. For example, if you are releasing version 1.2.3, the tag should be
+named `v1.2.3`.
+
+# Using Snapshots
+If you would like to live on the bleeding edge, you can try running against a snapshot build. Keep in mind that snapshots
+represent the most recent changes on master and may contain bugs.
+
+## build.gradle:
+
+```groovy
+repositories {
+  maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+}
+
+dependencies {
+  implementation 'com.eppo:eppo-jvm-common-sdk:1.0.0-SNAPSHOT'
+}
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'com.eppo:eppo-jvm-common-sdk:1.0.0'
+  implementation 'cloud.eppo:sdk-common-jvm:1.0.0'
 }
 ```
 
@@ -29,10 +29,10 @@ represent the most recent changes on master and may contain bugs.
 
 ```groovy
 repositories {
-  maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+  maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 dependencies {
-  implementation 'com.eppo:eppo-jvm-common-sdk:1.0.0-SNAPSHOT'
+  implementation 'cloud.eppo:sdk-common-jvm:1.0.0-SNAPSHOT'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ publishing {
 
 signing {
   sign publishing.publications.mavenJava
+  useInMemoryPgpKeys(System.env.GPG_PRIVATE_KEY, System.env.GPG_PASSPHRASE)
 }
 
 


### PR DESCRIPTION
# Description

This PR makes it so every push to `main` will publish a new SNAPSHOT version of the library to Sonatype. This will be the bleeding edge version.

Configured all secrets and verified that the workflow works as intended. Release showed up here https://s01.oss.sonatype.org/content/repositories/snapshots/cloud/eppo/sdk-common-jvm/1.0.0-SNAPSHOT/