### PR TITLE
chore: Prepare for next release iteration

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -8,6 +8,7 @@ on:
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+  CI: true
 
 jobs:
   lint-test-sdk:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -7,6 +7,7 @@ on:
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+  CI: true
 
 jobs:
   publish:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -23,9 +23,6 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Download test data
-        run: make test-data
-
       - name: Publish to Maven Central
         run: ./gradlew publish --no-daemon
         env:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish Snapshot artifact
-        run: ./gradlew publish --no-daemon
+        run: ./gradlew check publish --no-daemon
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,6 +7,7 @@ on:
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+  CI: true
 
 jobs:
   publish-snapshot:

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ You haven't yet, generate a user token on `s01.oss.sonatype.org` and add it to y
 Also make sure you have a configured GPG key for signing the artifact.
 
 1. Make sure you have the following vars in your `~/.gradle/gradle.properties` file:
-    1.1. `ossrhUsername` - User token username for Sonatype
-    1.2. `ossrhPassword` - User token password for Sonatype
-    1.3. `signing.keyId` - GPG key ID
-    1.4. `signing.password` - GPG key password
-    1.4. `signing.secretKeyRingFile` - Path to GPG key file
+   1. `ossrhUsername` - User token username for Sonatype
+   2. `ossrhPassword` - User token password for Sonatype
+   3. `signing.keyId` - GPG key ID
+   4. `signing.password` - GPG key password
+   5. `signing.secretKeyRingFile` - Path to GPG key file
 2. Bump the project version in `build.gradle`
 3. Run `./gradlew publish`
 4. Follow the steps in [this page](https://central.sonatype.org/publish/release/#credentials) to promote your release

--- a/README.md
+++ b/README.md
@@ -18,18 +18,22 @@ dependencies {
 
 For publishing a release locally, follow the steps below.
 
-You haven't yet, generate a user token on `s01.oss.sonatype.org` and add it to your `~/.gradle/gradle.properties` file.
-Also make sure you have a [configured GPG key](https://central.sonatype.org/publish/requirements/gpg/) for signing the artifact.
+### Prerequisites
 
-1. Make sure you have the following vars in your `~/.gradle/gradle.properties` file:
-   1. `ossrhUsername` - User token username for Sonatype
-   2. `ossrhPassword` - User token password for Sonatype
-   3. `signing.keyId` - GPG key ID
-   4. `signing.password` - GPG key password
-   5. `signing.secretKeyRingFile` - Path to GPG key file
-2. Bump the project version in `build.gradle`
-3. Run `./gradlew publish`
-4. Follow the steps in [this page](https://central.sonatype.org/publish/release/#credentials) to promote your release
+1. [Generate a user token](https://central.sonatype.org/publish/generate-token/) on `s01.oss.sonatype.org`;
+2. [Configure a GPG key](https://central.sonatype.org/publish/requirements/gpg/) for signing the artifact. Don't forget to upload it to the key server;
+3. Make sure you have the following vars in your `~/.gradle/gradle.properties` file:
+   1. `ossrhUsername` - User token username for Sonatype generated in step 1
+   2. `ossrhPassword` - User token password for Sonatype generated in step 1
+   3. `signing.keyId` - GPG key ID generated in step 2
+   4. `signing.password` - GPG key password generated in step 2
+   5. `signing.secretKeyRingFile` - Path to GPG key file generated in step 2
+
+Once you have the prerequisites, follow the steps below to release a new version:
+
+1. Bump the project version in `build.gradle`
+2. Run `./gradlew publish`
+3. Follow the steps in [this page](https://central.sonatype.org/publish/release/#credentials) to promote your release
 
 ## Using Snapshots
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dependencies {
 For publishing a release locally, follow the steps below.
 
 You haven't yet, generate a user token on `s01.oss.sonatype.org` and add it to your `~/.gradle/gradle.properties` file.
-Also make sure you have a configured GPG key for signing the artifact.
+Also make sure you have a [configured GPG key](https://central.sonatype.org/publish/requirements/gpg/) for signing the artifact.
 
 1. Make sure you have the following vars in your `~/.gradle/gradle.properties` file:
    1. `ossrhUsername` - User token username for Sonatype

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is the common SDK for the Eppo JVM SDKs. It provides a set of classes and i
 interact with the Eppo API. You should probably not use this library directly and instead use the [Android](https://github.com/Eppo-exp/android-sdk)
 or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
-# Usage
+## Usage
 
-## build.gradle:
+### build.gradle:
 
 ```groovy
 dependencies {
@@ -14,18 +14,18 @@ dependencies {
 }
 ```
 
-# Releasing a new version
+## Releasing a new version
 
-Bump the project version in `build.gradle`
-To release a new version of the SDK, you need to create a new tag in the repository. The tag should be named `vX.Y.Z`,
+1. Bump the project version in `build.gradle`
+2. To release a new version of the SDK, you need to create a new tag in the repository. The tag should be named `vX.Y.Z`,
 where `X.Y.Z` is the version number of the release. For example, if you are releasing version 1.2.3, the tag should be
 named `v1.2.3`.
 
-# Using Snapshots
+## Using Snapshots
 If you would like to live on the bleeding edge, you can try running against a snapshot build. Keep in mind that snapshots
 represent the most recent changes on master and may contain bugs.
 
-## build.gradle:
+### build.gradle:
 
 ```groovy
 repositories {

--- a/README.md
+++ b/README.md
@@ -16,14 +16,26 @@ dependencies {
 
 ## Releasing a new version
 
-1. Bump the project version in `build.gradle`
-2. To release a new version of the SDK, you need to create a new tag in the repository. The tag should be named `vX.Y.Z`,
-where `X.Y.Z` is the version number of the release. For example, if you are releasing version 1.2.3, the tag should be
-named `v1.2.3`.
+For publishing a release locally, follow the steps below.
+
+You haven't yet, generate a user token on `s01.oss.sonatype.org` and add it to your `~/.gradle/gradle.properties` file.
+Also make sure you have a configured GPG key for signing the artifact
+
+1. Make sure you have the following vars in your `~/.gradle/gradle.properties` file:
+    1.1 `ossrhUsername` - User token username for Sonatype
+    1.2 `ossrhPassword` - User token password for Sonatype
+    1.3 `signing.keyId` - GPG key ID
+    1.4 `signing.password` - GPG key password
+    1.4 `signing.secretKeyRingFile` - Path to GPG key file
+2. Bump the project version in `build.gradle`
+3. Run `./gradlew publish`
+4. Follow the steps in [this page](https://central.sonatype.org/publish/release/#credentials) to promote your release
 
 ## Using Snapshots
+
 If you would like to live on the bleeding edge, you can try running against a snapshot build. Keep in mind that snapshots
 represent the most recent changes on master and may contain bugs.
+Snapshots are published automatically after each push to `main` branch.
 
 ### build.gradle:
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ dependencies {
 For publishing a release locally, follow the steps below.
 
 You haven't yet, generate a user token on `s01.oss.sonatype.org` and add it to your `~/.gradle/gradle.properties` file.
-Also make sure you have a configured GPG key for signing the artifact
+Also make sure you have a configured GPG key for signing the artifact.
 
 1. Make sure you have the following vars in your `~/.gradle/gradle.properties` file:
-    1.1 `ossrhUsername` - User token username for Sonatype
-    1.2 `ossrhPassword` - User token password for Sonatype
-    1.3 `signing.keyId` - GPG key ID
-    1.4 `signing.password` - GPG key password
-    1.4 `signing.secretKeyRingFile` - Path to GPG key file
+    1.1. `ossrhUsername` - User token username for Sonatype
+    1.2. `ossrhPassword` - User token password for Sonatype
+    1.3. `signing.keyId` - GPG key ID
+    1.4. `signing.password` - GPG key password
+    1.4. `signing.secretKeyRingFile` - Path to GPG key file
 2. Bump the project version in `build.gradle`
 3. Run `./gradlew publish`
 4. Follow the steps in [this page](https://central.sonatype.org/publish/release/#credentials) to promote your release

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ publishing {
 
 signing {
   sign publishing.publications.mavenJava
-  if (project.hasProperty('CI')) {
+  if (System.env['CI']) {
     useInMemoryPgpKeys(System.env.GPG_PRIVATE_KEY, System.env.GPG_PASSPHRASE)
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '1.0.0-SNAPSHOT'
+version = '1.0.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,9 @@ publishing {
 
 signing {
   sign publishing.publications.mavenJava
-  useInMemoryPgpKeys(System.env.GPG_PRIVATE_KEY, System.env.GPG_PASSPHRASE)
+  if (project.hasProperty('CI')) {
+    useInMemoryPgpKeys(System.env.GPG_PRIVATE_KEY, System.env.GPG_PASSPHRASE)
+  }
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '1.0.0'
+version = '2.0.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 dependencies {


### PR DESCRIPTION
Just some housekeeping. Set the version to v1.0.0 so that will be the first non-snapshot version of this artifact. Then we can update both SDKs to use that instead of the snapshot version