### PR TITLE
chore: Build and publish artifacts with Java 8

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - '**/*'
+  push:
+    branches: [main]
 
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '8'
           distribution: 'adopt'
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
This makes sure that this library remains java 8 compatible, otherwise it can't be use from https://github.com/Eppo-exp/java-server-sdk