### PR TITLE
chore: Prepare for v2.0.0 release

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -25,7 +25,7 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to Maven Central
-        run: ./gradlew publish --no-daemon
+        run: ./gradlew publish -Prelease --no-daemon
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -25,7 +25,7 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to Maven Central
-        run: ./gradlew publish -Prelease --no-daemon
+        run: ./gradlew check publish -Prelease --no-daemon
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish Snapshot artifact
-        run: ./gradlew check publish --no-daemon
+        run: ./gradlew check publish -Psnapshot --no-daemon
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:1.0.0'
+  implementation 'cloud.eppo:sdk-common-jvm:2.0.0'
 }
 ```
 
@@ -49,6 +49,6 @@ repositories {
 }
 
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:1.0.0-SNAPSHOT'
+  implementation 'cloud.eppo:sdk-common-jvm:2.1.0-SNAPSHOT'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '2.0.0-SNAPSHOT'
+version = '2.0.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 dependencies {
@@ -97,6 +97,35 @@ publishing {
         password = project.properties.containsKey("ossrhPassword") ? project.properties["ossrhPassword"] : ""
       }
     }
+  }
+}
+
+// Custom task to ensure we can conditionally publish either a release or snapshot artifact
+// based on a command line switch. See github workflow files for more details on usage.
+task checkVersion {
+  doLast {
+    if (!project.hasProperty('release') && !project.hasProperty('snapshot')) {
+      throw new GradleException("You must specify either -Prelease or -Psnapshot")
+    }
+    if (project.hasProperty('release') && project.version.endsWith('SNAPSHOT')) {
+      throw new GradleException("You cannot specify -Prelease with a SNAPSHOT version")
+    }
+    if (project.hasProperty('snapshot') && !project.version.endsWith('SNAPSHOT')) {
+      throw new GradleException("You cannot specify -Psnapshot with a non-SNAPSHOT version")
+    }
+    project.ext.shouldPublish = true
+  }
+}
+
+// Ensure checkVersion runs before publishing
+tasks.named('publish').configure {
+  dependsOn checkVersion
+}
+
+// Conditionally enable or disable publishing tasks
+tasks.withType(PublishToMavenRepository) {
+  onlyIf {
+    project.ext.has('shouldPublish') && project.ext.shouldPublish
   }
 }
 


### PR DESCRIPTION
* Bump version to v2.0.0
* Update publish workflows to distinguish between snapshot and release