### PR TITLE
fix(ci): Add missing checkout fetch depth for spotless, version bump

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '2.0.0'
+version = '2.1.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 dependencies {


### PR DESCRIPTION
Should fix https://github.com/Eppo-exp/sdk-common-jdk/actions/runs/9765392722/job/26955946224