### PR TITLE
bug: [add support for json arrays in variant values] (FF-2947)

### DIFF
--- a/src/test/java/cloud/eppo/ufc/deserializer/FlagConfigResponseDeserializerTest.java
+++ b/src/test/java/cloud/eppo/ufc/deserializer/FlagConfigResponseDeserializerTest.java
@@ -37,6 +37,7 @@ public class FlagConfigResponseDeserializerTest {
     assertTrue(configResponse.getFlags().containsKey("new-user-onboarding"));
     assertTrue(configResponse.getFlags().containsKey("integer-flag"));
     assertTrue(configResponse.getFlags().containsKey("json-config-flag"));
+    assertTrue(configResponse.getFlags().containsKey("json-array-config-flag"));
 
     FlagConfig flagConfig = configResponse.getFlags().get("kill-switch");
     assertNotNull(flagConfig);
@@ -113,5 +114,20 @@ public class FlagConfigResponseDeserializerTest {
     Split offForAllSplit = offForAll.getSplits().iterator().next();
     assertEquals("off", offForAllSplit.getVariationKey());
     assertEquals(0, offForAllSplit.getShards().size());
+
+    // test for `json-array-config-flag` flag
+    FlagConfig jsonArrayConfigFlag = configResponse.getFlags().get("json-array-config-flag");
+    assertNotNull(jsonArrayConfigFlag);
+    jsonArrayConfigFlag.getVariations().forEach((key, variation) -> {
+      if (key.equals("one")) {
+        assertEquals("one", variation.getKey());
+        assertEquals("[{ \"integer\": 1, \"string\": \"one\", \"float\": 1.0 }, { \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }]", variation.getValue().stringValue());
+      } else if (key.equals("two")) {
+        assertEquals("two", variation.getKey());
+        assertEquals("[{ \"integer\": 3, \"string\": \"three\", \"float\": 3.0 }, { \"integer\": 4, \"string\": \"four\", \"float\": 4.0 }]", variation.getValue().stringValue());
+      } else {
+        fail("Unexpected variation key: " + key);
+      }
+    });
   }
 }

--- a/src/test/java/cloud/eppo/ufc/deserializer/FlagConfigResponseDeserializerTest.java
+++ b/src/test/java/cloud/eppo/ufc/deserializer/FlagConfigResponseDeserializerTest.java
@@ -118,16 +118,23 @@ public class FlagConfigResponseDeserializerTest {
     // test for `json-array-config-flag` flag
     FlagConfig jsonArrayConfigFlag = configResponse.getFlags().get("json-array-config-flag");
     assertNotNull(jsonArrayConfigFlag);
-    jsonArrayConfigFlag.getVariations().forEach((key, variation) -> {
-      if (key.equals("one")) {
-        assertEquals("one", variation.getKey());
-        assertEquals("[{ \"integer\": 1, \"string\": \"one\", \"float\": 1.0 }, { \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }]", variation.getValue().stringValue());
-      } else if (key.equals("two")) {
-        assertEquals("two", variation.getKey());
-        assertEquals("[{ \"integer\": 3, \"string\": \"three\", \"float\": 3.0 }, { \"integer\": 4, \"string\": \"four\", \"float\": 4.0 }]", variation.getValue().stringValue());
-      } else {
-        fail("Unexpected variation key: " + key);
-      }
-    });
+    jsonArrayConfigFlag
+        .getVariations()
+        .forEach(
+            (key, variation) -> {
+              if (key.equals("one")) {
+                assertEquals("one", variation.getKey());
+                assertEquals(
+                    "[{ \"integer\": 1, \"string\": \"one\", \"float\": 1.0 }, { \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }]",
+                    variation.getValue().stringValue());
+              } else if (key.equals("two")) {
+                assertEquals("two", variation.getKey());
+                assertEquals(
+                    "[{ \"integer\": 3, \"string\": \"three\", \"float\": 3.0 }, { \"integer\": 4, \"string\": \"four\", \"float\": 4.0 }]",
+                    variation.getValue().stringValue());
+              } else {
+                fail("Unexpected variation key: " + key);
+              }
+            });
   }
 }

--- a/src/test/resources/flags-v1.json
+++ b/src/test/resources/flags-v1.json
@@ -1,5 +1,8 @@
 {
   "createdAt": "2024-04-17T19:40:53.716Z",
+  "environment": {
+    "name": "Test"
+  },
   "flags": {
     "empty_flag": {
       "key": "empty_flag",
@@ -285,6 +288,10 @@
         "4": {
           "key": "4",
           "value": 4
+        },
+        "5": {
+          "key": "5",
+          "value": 5
         }
       },
       "allocations": [
@@ -371,6 +378,29 @@
           "splits": [
             {
               "variationKey": "4",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "5-for-matches-null",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "null_flag",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "5",
               "shards": []
             }
           ],
@@ -1097,6 +1127,77 @@
         "two": {
           "key": "two",
           "value": "{ \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }"
+        }
+      },
+      "allocations": [
+        {
+          "key": "50/50 split",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "one",
+              "shards": [
+                {
+                  "salt": "traffic-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "two",
+              "shards": [
+                {
+                  "salt": "traffic-json-flag",
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-json-flag",
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
+    "json-array-config-flag": {
+      "key": "json-array-config-flag",
+      "enabled": true,
+      "variationType": "JSON",
+      "variations": {
+        "one": {
+          "key": "one",
+          "value": "[{ \"integer\": 1, \"string\": \"one\", \"float\": 1.0 }, { \"integer\": 2, \"string\": \"two\", \"float\": 2.0 }]"
+        },
+        "two": {
+          "key": "two",
+          "value": "[{ \"integer\": 3, \"string\": \"three\", \"float\": 3.0 }, { \"integer\": 4, \"string\": \"four\", \"float\": 4.0 }]"
         }
       },
       "allocations": [


### PR DESCRIPTION
## observation

bug report observed that variation values with top level JSON arrays were throwing an exception, in the android SDK: https://github.com/Eppo-exp/android-sdk/blob/b95c1ce20b6b433a2b8722144e6edb5996e7cf4a/eppo/src/main/java/cloud/eppo/android/EppoClient.java#L438

## changes

I was tracing the code to determine where the parsing was happening and updated the unit tests in this repo.

Have learned that there is no direct support for JSON objects in this repo, so no broken tests to fix. Just augmenting them in this PR.

A few things to consider:

* there is a copy of the `flags-v1.json` in this repo but no easy way to update it: consider using a Makefile to clone the repo or make the test data repo a submodule.