### PR TITLE
Rename base EppoClient class to BaseEppoClient

### DIFF
--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EppoClient {
-  private static final Logger log = LoggerFactory.getLogger(EppoClient.class);
+public class BaseEppoClient {
+  private static final Logger log = LoggerFactory.getLogger(BaseEppoClient.class);
   private final ObjectMapper mapper =
       new ObjectMapper()
           .registerModule(EppoModule.eppoModule()); // TODO: is this the best place for this?
@@ -34,14 +34,14 @@ public class EppoClient {
   private final boolean isConfigObfuscated;
   private boolean isGracefulMode;
 
-  private static EppoClient instance;
+  private static BaseEppoClient instance;
 
   // Fields useful for testing in situations where we want to mock the http client or configuration
   // store (accessed via reflection)
   /** @noinspection FieldMayBeFinal */
   private static EppoHttpClient httpClientOverride = null;
 
-  private EppoClient(
+  private BaseEppoClient(
       String apiKey,
       String sdkName,
       String sdkVersion,
@@ -78,7 +78,7 @@ public class EppoClient {
     return httpClient;
   }
 
-  public static EppoClient init(
+  public static BaseEppoClient init(
       String apiKey,
       String sdkName,
       String sdkVersion,
@@ -100,7 +100,7 @@ public class EppoClient {
       log.warn("Reinitializing an Eppo Client instance that was already initialized");
     }
     instance =
-        new EppoClient(
+        new BaseEppoClient(
             apiKey,
             sdkName,
             sdkVersion,
@@ -479,12 +479,12 @@ public class EppoClient {
     throw new RuntimeException(e);
   }
 
-  public static EppoClient getInstance() {
-    if (EppoClient.instance == null) {
+  public static BaseEppoClient getInstance() {
+    if (BaseEppoClient.instance == null) {
       throw new IllegalStateException("Eppo SDK has not been initialized");
     }
 
-    return EppoClient.instance;
+    return BaseEppoClient.instance;
   }
 
   public void setIsGracefulFailureMode(boolean isGracefulFailureMode) {
@@ -535,8 +535,8 @@ public class EppoClient {
       return this;
     }
 
-    public EppoClient buildAndInit() {
-      return EppoClient.init(
+    public BaseEppoClient buildAndInit() {
+      return BaseEppoClient.init(
           apiKey, sdkName, sdkVersion, host, assignmentLogger, banditLogger, isGracefulMode);
     }
   }

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -27,8 +27,8 @@ import org.mockito.MockedStatic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EppoClientBanditTest {
-  private static final Logger log = LoggerFactory.getLogger(EppoClientBanditTest.class);
+public class BaseEppoClientBanditTest {
+  private static final Logger log = LoggerFactory.getLogger(BaseEppoClientBanditTest.class);
   private static final String DUMMY_BANDIT_API_KEY =
       "dummy-bandits-api-key"; // Will load bandit-flags-v1
   private static final String TEST_HOST =
@@ -44,7 +44,7 @@ public class EppoClientBanditTest {
   @BeforeAll
   public static void initClient() {
 
-    new EppoClient.Builder()
+    new BaseEppoClient.Builder()
         .apiKey(DUMMY_BANDIT_API_KEY)
         .sdkName("java")
         .sdkVersion("3.0.0")
@@ -62,7 +62,7 @@ public class EppoClientBanditTest {
     clearInvocations(mockAssignmentLogger);
     clearInvocations(mockBanditLogger);
     doNothing().when(mockBanditLogger).logBanditAssignment(any());
-    EppoClient.getInstance().setIsGracefulFailureMode(false);
+    BaseEppoClient.getInstance().setIsGracefulFailureMode(false);
   }
 
   @ParameterizedTest
@@ -106,7 +106,7 @@ public class EppoClientBanditTest {
       ContextAttributes attributes = subjectAssignment.getSubjectAttributes();
       Actions actions = subjectAssignment.getActions();
       BanditResult assignment =
-          EppoClient.getInstance()
+          BaseEppoClient.getInstance()
               .getBanditAction(flagKey, subjectKey, attributes, actions, defaultValue);
       assertBanditAssignment(flagKey, subjectAssignment, assignment);
     }
@@ -165,7 +165,7 @@ public class EppoClientBanditTest {
     actions.put("reebok", rebookAttributes);
 
     BanditResult banditResult =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getBanditAction(flagKey, subjectKey, subjectAttributes, actions, "control");
 
     // Verify assignment
@@ -239,7 +239,7 @@ public class EppoClientBanditTest {
     actions.put("adidas", new Attributes());
 
     BanditResult banditResult =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getBanditAction(flagKey, subjectKey, subjectAttributes, actions, "default");
 
     // Verify assignment
@@ -267,7 +267,7 @@ public class EppoClientBanditTest {
     BanditActions actions = new BanditActions();
 
     BanditResult banditResult =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getBanditAction(flagKey, subjectKey, subjectAttributes, actions, "control");
 
     // Verify assignment
@@ -286,7 +286,7 @@ public class EppoClientBanditTest {
 
   @Test
   public void testBanditErrorGracefulModeOff() {
-    EppoClient.getInstance()
+    BaseEppoClient.getInstance()
         .setIsGracefulFailureMode(
             false); // Should be set by @BeforeEach but repeated here for test clarity
     try (MockedStatic<BanditEvaluator> mockedStatic = mockStatic(BanditEvaluator.class)) {
@@ -302,7 +302,7 @@ public class EppoClientBanditTest {
       assertThrows(
           RuntimeException.class,
           () ->
-              EppoClient.getInstance()
+              BaseEppoClient.getInstance()
                   .getBanditAction(
                       "banner_bandit_flag", "subject", new Attributes(), actions, "default"));
     }
@@ -310,7 +310,7 @@ public class EppoClientBanditTest {
 
   @Test
   public void testBanditErrorGracefulModeOn() {
-    EppoClient.getInstance().setIsGracefulFailureMode(true);
+    BaseEppoClient.getInstance().setIsGracefulFailureMode(true);
     try (MockedStatic<BanditEvaluator> mockedStatic = mockStatic(BanditEvaluator.class)) {
       // Configure the mock to throw an exception
       mockedStatic
@@ -322,7 +322,7 @@ public class EppoClientBanditTest {
       actions.put("nike", new Attributes());
       actions.put("adidas", new Attributes());
       BanditResult banditResult =
-          EppoClient.getInstance()
+          BaseEppoClient.getInstance()
               .getBanditAction(
                   "banner_bandit_flag", "subject", new Attributes(), actions, "default");
       assertEquals("banner_bandit", banditResult.getVariation());
@@ -341,7 +341,7 @@ public class EppoClientBanditTest {
     actions.put("nike", new Attributes());
     actions.put("adidas", new Attributes());
     BanditResult banditResult =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getBanditAction("banner_bandit_flag", "subject", new Attributes(), actions, "default");
     assertEquals("banner_bandit", banditResult.getVariation());
     assertEquals("nike", banditResult.getAction());

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -39,8 +39,8 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EppoClientTest {
-  private static final Logger log = LoggerFactory.getLogger(EppoClientTest.class);
+public class BaseEppoClientTest {
+  private static final Logger log = LoggerFactory.getLogger(BaseEppoClientTest.class);
   private static final String DUMMY_FLAG_API_KEY = "dummy-flags-api-key"; // Will load flags-v1
   private static final String TEST_HOST =
       "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile";
@@ -58,7 +58,7 @@ public class EppoClientTest {
       String host, boolean isGracefulMode, boolean isConfigObfuscated, String apiKey) {
     mockAssignmentLogger = mock(AssignmentLogger.class);
 
-    new EppoClient.Builder()
+    new BaseEppoClient.Builder()
         .apiKey(apiKey)
         .sdkName(isConfigObfuscated ? "android" : "java")
         .sdkVersion("3.0.0")
@@ -118,7 +118,7 @@ public class EppoClientTest {
   private void runTestCase(AssignmentTestCase testCase) {
     String flagKey = testCase.getFlag();
     TestCaseValue defaultValue = testCase.getDefaultValue();
-    EppoClient eppoClient = EppoClient.getInstance();
+    BaseEppoClient eppoClient = BaseEppoClient.getInstance();
     assertFalse(testCase.getSubjects().isEmpty());
 
     for (SubjectAssignment subjectAssignment : testCase.getSubjects()) {
@@ -222,8 +222,8 @@ public class EppoClientTest {
   public void testErrorGracefulModeOn() throws JsonProcessingException {
     initClient(TEST_HOST, true, false, DUMMY_FLAG_API_KEY);
 
-    EppoClient realClient = EppoClient.getInstance();
-    EppoClient spyClient = spy(realClient);
+    BaseEppoClient realClient = BaseEppoClient.getInstance();
+    BaseEppoClient spyClient = spy(realClient);
     doThrow(new RuntimeException("Exception thrown by mock"))
         .when(spyClient)
         .getTypedAssignment(
@@ -271,8 +271,8 @@ public class EppoClientTest {
   public void testErrorGracefulModeOff() {
     initClient(TEST_HOST, false, false, DUMMY_FLAG_API_KEY);
 
-    EppoClient realClient = EppoClient.getInstance();
-    EppoClient spyClient = spy(realClient);
+    BaseEppoClient realClient = BaseEppoClient.getInstance();
+    BaseEppoClient spyClient = spy(realClient);
     doThrow(new RuntimeException("Exception thrown by mock"))
         .when(spyClient)
         .getTypedAssignment(
@@ -330,7 +330,7 @@ public class EppoClientTest {
     initClient(TEST_HOST, false, false, DUMMY_FLAG_API_KEY);
 
     String result =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getStringAssignment("dummy subject", "dummy flag", "not-populated");
     assertEquals("not-populated", result);
   }
@@ -343,7 +343,7 @@ public class EppoClientTest {
     subjectAttributes.put("age", EppoValue.valueOf(30));
     subjectAttributes.put("employer", EppoValue.valueOf("Eppo"));
     double assignment =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getDoubleAssignment("numeric_flag", "alice", subjectAttributes, 0.0);
 
     assertEquals(3.1415926, assignment, 0.0000001);
@@ -381,7 +381,7 @@ public class EppoClientTest {
         .when(mockAssignmentLogger)
         .logAssignment(any());
     double assignment =
-        EppoClient.getInstance()
+        BaseEppoClient.getInstance()
             .getDoubleAssignment("numeric_flag", "alice", new Attributes(), 0.0);
 
     assertEquals(3.1415926, assignment, 0.0000001);
@@ -431,7 +431,7 @@ public class EppoClientTest {
   /** Uses reflection to set a static override field used for tests (e.g., httpClientOverride) */
   private <T> void setOverrideField(String fieldName, T override) {
     try {
-      Field httpClientOverrideField = EppoClient.class.getDeclaredField(fieldName);
+      Field httpClientOverrideField = BaseEppoClient.class.getDeclaredField(fieldName);
       httpClientOverrideField.setAccessible(true);
       httpClientOverrideField.set(null, override);
       httpClientOverrideField.setAccessible(false);


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3012 - Rename shared EppoClient class so upstream SDKs can extend as EppoClient](https://linear.app/eppo/issue/FF-3012/rename-shared-eppoclient-class-so-upstream-sdks-can-extend-as)

To keep things simple for users of our SDKs, our plan is to have the Java and Android Eppo Client classes to continue to be EppoClient. To take advantage of this shared common repository, we want to rename the shared base client class for each SDK to extend.