### PR TITLE
Improvements for use by eventual application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,15 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.0.1-SNAPSHOT'
+version = '3.0.2-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+  withJavadocJar()
+  withSourcesJar()
+}
 
 dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
@@ -56,11 +63,6 @@ spotless {
     // fix formatting of type annotations
     formatAnnotations()
   }
-}
-
-java {
-  withJavadocJar()
-  withSourcesJar()
 }
 
 tasks.register('testJar', Jar) {

--- a/src/main/java/cloud/eppo/BanditEvaluationResult.java
+++ b/src/main/java/cloud/eppo/BanditEvaluationResult.java
@@ -1,6 +1,6 @@
 package cloud.eppo;
 
-import cloud.eppo.ufc.dto.DiscriminableAttributes;
+import cloud.eppo.api.DiscriminableAttributes;
 
 public class BanditEvaluationResult {
 

--- a/src/main/java/cloud/eppo/BanditEvaluator.java
+++ b/src/main/java/cloud/eppo/BanditEvaluator.java
@@ -2,6 +2,10 @@ package cloud.eppo;
 
 import static cloud.eppo.Utils.getShard;
 
+import cloud.eppo.api.Actions;
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.DiscriminableAttributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.ufc.dto.*;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -3,6 +3,7 @@ package cloud.eppo;
 import static cloud.eppo.Utils.getMD5Hex;
 import static cloud.eppo.Utils.throwIfEmptyOrNull;
 
+import cloud.eppo.api.*;
 import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditAssignment;

--- a/src/main/java/cloud/eppo/FlagEvaluationResult.java
+++ b/src/main/java/cloud/eppo/FlagEvaluationResult.java
@@ -1,6 +1,6 @@
 package cloud.eppo;
 
-import cloud.eppo.ufc.dto.Attributes;
+import cloud.eppo.api.Attributes;
 import cloud.eppo.ufc.dto.Variation;
 import java.util.Map;
 

--- a/src/main/java/cloud/eppo/FlagEvaluator.java
+++ b/src/main/java/cloud/eppo/FlagEvaluator.java
@@ -3,10 +3,10 @@ package cloud.eppo;
 import static cloud.eppo.Utils.base64Decode;
 import static cloud.eppo.Utils.getShard;
 
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.model.ShardRange;
 import cloud.eppo.ufc.dto.Allocation;
-import cloud.eppo.ufc.dto.Attributes;
-import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.Shard;
 import cloud.eppo.ufc.dto.Split;

--- a/src/main/java/cloud/eppo/RuleEvaluator.java
+++ b/src/main/java/cloud/eppo/RuleEvaluator.java
@@ -3,8 +3,8 @@ package cloud.eppo;
 import static cloud.eppo.Utils.base64Decode;
 import static cloud.eppo.Utils.getMD5Hex;
 
-import cloud.eppo.ufc.dto.Attributes;
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.ufc.dto.OperatorType;
 import cloud.eppo.ufc.dto.TargetingCondition;
 import cloud.eppo.ufc.dto.TargetingRule;

--- a/src/main/java/cloud/eppo/api/Actions.java
+++ b/src/main/java/cloud/eppo/api/Actions.java
@@ -1,4 +1,4 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
 import java.util.Map;
 

--- a/src/main/java/cloud/eppo/api/Attributes.java
+++ b/src/main/java/cloud/eppo/api/Attributes.java
@@ -1,5 +1,8 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,5 +63,44 @@ public class Attributes extends HashMap<String, EppoValue> implements Discrimina
   @Override
   public Attributes getAllAttributes() {
     return this;
+  }
+
+  /** Serializes the attributes to a JSON string, omitting attributes with a null value. */
+  public String serializeNonNullAttributesToJSONString() {
+    return serializeAttributesToJSONString(true);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private String serializeAttributesToJSONString(boolean omitNulls) {
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode result = mapper.createObjectNode();
+
+    for (Map.Entry<String, EppoValue> entry : entrySet()) {
+      String attributeName = entry.getKey();
+      EppoValue attributeValue = entry.getValue();
+
+      if (attributeValue == null || attributeValue.isNull()) {
+        if (!omitNulls) {
+          result.putNull(attributeName);
+        }
+      } else {
+        if (attributeValue.isNumeric()) {
+          result.put(attributeName, attributeValue.doubleValue());
+          continue;
+        }
+        if (attributeValue.isBoolean()) {
+          result.put(attributeName, attributeValue.booleanValue());
+          continue;
+        }
+        // fall back put treating any other eppo values as a string
+        result.put(attributeName, attributeValue.toString());
+      }
+    }
+
+    try {
+      return mapper.writeValueAsString(result);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/main/java/cloud/eppo/api/BanditActions.java
+++ b/src/main/java/cloud/eppo/api/BanditActions.java
@@ -1,4 +1,4 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,7 +10,7 @@ public class BanditActions extends HashMap<String, DiscriminableAttributes> impl
     super();
   }
 
-  public BanditActions(Map<String, DiscriminableAttributes> actionsWithContext) {
+  public BanditActions(Map<String, ? extends DiscriminableAttributes> actionsWithContext) {
     super(actionsWithContext);
   }
 

--- a/src/main/java/cloud/eppo/api/BanditResult.java
+++ b/src/main/java/cloud/eppo/api/BanditResult.java
@@ -1,4 +1,4 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
 public class BanditResult {
   private final String variation;

--- a/src/main/java/cloud/eppo/api/ContextAttributes.java
+++ b/src/main/java/cloud/eppo/api/ContextAttributes.java
@@ -1,4 +1,4 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/cloud/eppo/api/DiscriminableAttributes.java
+++ b/src/main/java/cloud/eppo/api/DiscriminableAttributes.java
@@ -1,4 +1,4 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
 public interface DiscriminableAttributes {
 

--- a/src/main/java/cloud/eppo/api/EppoValue.java
+++ b/src/main/java/cloud/eppo/api/EppoValue.java
@@ -1,5 +1,6 @@
-package cloud.eppo.ufc.dto;
+package cloud.eppo.api;
 
+import cloud.eppo.ufc.dto.EppoValueType;
 import java.util.List;
 import java.util.Objects;
 

--- a/src/main/java/cloud/eppo/logging/Assignment.java
+++ b/src/main/java/cloud/eppo/logging/Assignment.java
@@ -1,6 +1,6 @@
 package cloud.eppo.logging;
 
-import cloud.eppo.ufc.dto.Attributes;
+import cloud.eppo.api.Attributes;
 import java.util.Date;
 import java.util.Map;
 

--- a/src/main/java/cloud/eppo/logging/BanditAssignment.java
+++ b/src/main/java/cloud/eppo/logging/BanditAssignment.java
@@ -1,6 +1,6 @@
 package cloud.eppo.logging;
 
-import cloud.eppo.ufc.dto.Attributes;
+import cloud.eppo.api.Attributes;
 import java.util.Date;
 import java.util.Map;
 

--- a/src/main/java/cloud/eppo/ufc/dto/BanditAttributeCoefficients.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditAttributeCoefficients.java
@@ -1,5 +1,7 @@
 package cloud.eppo.ufc.dto;
 
+import cloud.eppo.api.EppoValue;
+
 public interface BanditAttributeCoefficients {
 
   String getAttributeKey();

--- a/src/main/java/cloud/eppo/ufc/dto/BanditCategoricalAttributeCoefficients.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditCategoricalAttributeCoefficients.java
@@ -1,5 +1,6 @@
 package cloud.eppo.ufc.dto;
 
+import cloud.eppo.api.EppoValue;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/cloud/eppo/ufc/dto/BanditNumericAttributeCoefficients.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditNumericAttributeCoefficients.java
@@ -1,5 +1,6 @@
 package cloud.eppo.ufc.dto;
 
+import cloud.eppo.api.EppoValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/cloud/eppo/ufc/dto/TargetingCondition.java
+++ b/src/main/java/cloud/eppo/ufc/dto/TargetingCondition.java
@@ -1,5 +1,7 @@
 package cloud.eppo.ufc.dto;
 
+import cloud.eppo.api.EppoValue;
+
 public class TargetingCondition {
   private final OperatorType operator;
   private final String attribute;

--- a/src/main/java/cloud/eppo/ufc/dto/Variation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Variation.java
@@ -1,5 +1,7 @@
 package cloud.eppo.ufc.dto;
 
+import cloud.eppo.api.EppoValue;
+
 public class Variation {
   private final String key;
   private final EppoValue value;

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/EppoModule.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/EppoModule.java
@@ -1,7 +1,7 @@
 package cloud.eppo.ufc.dto.adapters;
 
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.ufc.dto.BanditParametersResponse;
-import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfigResponse;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.util.Date;

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueDeserializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueDeserializer.java
@@ -1,6 +1,6 @@
 package cloud.eppo.ufc.dto.adapters;
 
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.EppoValue;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueSerializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueSerializer.java
@@ -1,6 +1,6 @@
 package cloud.eppo.ufc.dto.adapters;
 
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.EppoValue;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseDeserializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseDeserializer.java
@@ -2,6 +2,7 @@ package cloud.eppo.ufc.dto.adapters;
 
 import static cloud.eppo.Utils.parseUtcISODateNode;
 
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.model.ShardRange;
 import cloud.eppo.ufc.dto.*;
 import com.fasterxml.jackson.core.JacksonException;

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -5,12 +5,14 @@ import static cloud.eppo.helpers.BanditTestCase.runBanditTestCase;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.BanditActions;
+import cloud.eppo.api.BanditResult;
 import cloud.eppo.helpers.*;
 import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;
 import cloud.eppo.logging.BanditAssignment;
 import cloud.eppo.logging.BanditLogger;
-import cloud.eppo.ufc.dto.*;
 import java.io.File;
 import java.util.*;
 import java.util.stream.Stream;
@@ -139,6 +141,7 @@ public class BaseEppoClientBanditTest {
     assertEquals(subjectKey, capturedBanditAssignment.getSubject());
     assertEquals("adidas", capturedBanditAssignment.getAction());
     assertEquals(0.099, capturedBanditAssignment.getActionProbability(), 0.0002);
+    assertEquals(7.1, capturedBanditAssignment.getOptimalityGap(), 0.0002);
     assertEquals("v123", capturedBanditAssignment.getModelVersion());
 
     Attributes expectedSubjectNumericAttributes = new Attributes();

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -10,11 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.helpers.AssignmentTestCase;
 import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;
-import cloud.eppo.ufc.dto.Attributes;
-import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.VariationType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/cloud/eppo/EppoValueTest.java
+++ b/src/test/java/cloud/eppo/EppoValueTest.java
@@ -2,7 +2,7 @@ package cloud.eppo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.EppoValue;
 import org.junit.jupiter.api.Test;
 
 public class EppoValueTest {

--- a/src/test/java/cloud/eppo/FlagEvaluatorTest.java
+++ b/src/test/java/cloud/eppo/FlagEvaluatorTest.java
@@ -4,10 +4,10 @@ import static cloud.eppo.Utils.base64Encode;
 import static cloud.eppo.Utils.getMD5Hex;
 import static org.junit.jupiter.api.Assertions.*;
 
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.model.ShardRange;
 import cloud.eppo.ufc.dto.Allocation;
-import cloud.eppo.ufc.dto.Attributes;
-import cloud.eppo.ufc.dto.EppoValue;
 import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.OperatorType;
 import cloud.eppo.ufc.dto.Shard;

--- a/src/test/java/cloud/eppo/ProfileBaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/ProfileBaseEppoClientTest.java
@@ -3,9 +3,9 @@ package cloud.eppo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import cloud.eppo.api.Attributes;
 import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;
-import cloud.eppo.ufc.dto.Attributes;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.HashMap;

--- a/src/test/java/cloud/eppo/RuleEvaluatorTest.java
+++ b/src/test/java/cloud/eppo/RuleEvaluatorTest.java
@@ -3,8 +3,8 @@ package cloud.eppo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import cloud.eppo.ufc.dto.Attributes;
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.ufc.dto.OperatorType;
 import cloud.eppo.ufc.dto.TargetingCondition;
 import cloud.eppo.ufc.dto.TargetingRule;

--- a/src/test/java/cloud/eppo/helpers/AssignmentTestCase.java
+++ b/src/test/java/cloud/eppo/helpers/AssignmentTestCase.java
@@ -3,7 +3,7 @@ package cloud.eppo.helpers;
 import static org.junit.jupiter.api.Assertions.*;
 
 import cloud.eppo.BaseEppoClient;
-import cloud.eppo.ufc.dto.Attributes;
+import cloud.eppo.api.Attributes;
 import cloud.eppo.ufc.dto.VariationType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/cloud/eppo/helpers/AssignmentTestCaseDeserializer.java
+++ b/src/test/java/cloud/eppo/helpers/AssignmentTestCaseDeserializer.java
@@ -1,7 +1,7 @@
 package cloud.eppo.helpers;
 
-import cloud.eppo.ufc.dto.Attributes;
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.Attributes;
+import cloud.eppo.api.EppoValue;
 import cloud.eppo.ufc.dto.VariationType;
 import cloud.eppo.ufc.dto.adapters.EppoValueDeserializer;
 import com.fasterxml.jackson.core.JsonParser;

--- a/src/test/java/cloud/eppo/helpers/BanditSubjectAssignment.java
+++ b/src/test/java/cloud/eppo/helpers/BanditSubjectAssignment.java
@@ -1,8 +1,8 @@
 package cloud.eppo.helpers;
 
-import cloud.eppo.ufc.dto.Actions;
-import cloud.eppo.ufc.dto.BanditResult;
-import cloud.eppo.ufc.dto.ContextAttributes;
+import cloud.eppo.api.Actions;
+import cloud.eppo.api.BanditResult;
+import cloud.eppo.api.ContextAttributes;
 
 public class BanditSubjectAssignment {
   private final String subjectKey;

--- a/src/test/java/cloud/eppo/helpers/BanditTestCase.java
+++ b/src/test/java/cloud/eppo/helpers/BanditTestCase.java
@@ -4,9 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import cloud.eppo.BaseEppoClient;
-import cloud.eppo.ufc.dto.Actions;
-import cloud.eppo.ufc.dto.BanditResult;
-import cloud.eppo.ufc.dto.ContextAttributes;
+import cloud.eppo.api.Actions;
+import cloud.eppo.api.BanditResult;
+import cloud.eppo.api.ContextAttributes;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.File;

--- a/src/test/java/cloud/eppo/helpers/BanditTestCaseDeserializer.java
+++ b/src/test/java/cloud/eppo/helpers/BanditTestCaseDeserializer.java
@@ -1,6 +1,6 @@
 package cloud.eppo.helpers;
 
-import cloud.eppo.ufc.dto.*;
+import cloud.eppo.api.*;
 import cloud.eppo.ufc.dto.adapters.EppoValueDeserializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/src/test/java/cloud/eppo/helpers/SubjectAssignment.java
+++ b/src/test/java/cloud/eppo/helpers/SubjectAssignment.java
@@ -1,6 +1,6 @@
 package cloud.eppo.helpers;
 
-import cloud.eppo.ufc.dto.Attributes;
+import cloud.eppo.api.Attributes;
 
 public class SubjectAssignment {
   private final String subjectKey;

--- a/src/test/java/cloud/eppo/helpers/TestCaseValue.java
+++ b/src/test/java/cloud/eppo/helpers/TestCaseValue.java
@@ -1,6 +1,6 @@
 package cloud.eppo.helpers;
 
-import cloud.eppo.ufc.dto.EppoValue;
+import cloud.eppo.api.EppoValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3066 - Improve common SDK for use by customer apps](https://linear.app/eppo/issue/FF-3066/improve-common-sdk-for-use-by-customer-apps)
👯‍♀️ **Related PR:** [`java-bandit-proxy #7`](https://github.com/Eppo-exp/java-bandit-proxy/pull/7)

To make it so the eventual application using the Java or Android SDK can use interfaces defined in here, their packaging will expose the API of this package. To help make it clear which classes are actually used via exposure, we've created an `api` package and put the relevant interfaces and classes in there.

We also create a new method on `Attributes` that serialize the instance to a JSON string. This is very useful when logging, as people will want to save these as JSON to their data warehouses. (Note: we are ressurecting a flavor of this from the old Java SDK).

Also, to ensure compatibility with Java 8 we set the compile target.