### PR TITLE
Include Java version 21 in tests

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['8', '11', '17'] # Define the Java versions to test against
+        java-version: ['8', '11', '17', '21'] # Define the Java versions to test against
     steps:
       - uses: actions/checkout@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,11 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.skyscreamer:jsonassert:1.5.3'
   testImplementation 'commons-io:commons-io:2.11.0'
-  testImplementation "com.google.truth:truth:1.4.4"
-  testImplementation 'org.mockito:mockito-core:4.11.0'
+  testImplementation 'com.google.truth:truth:1.4.4'
+  testImplementation ('org.mockito:mockito-core:4.11.0') {
+    exclude group: 'net.bytebuddy', module: 'byte-buddy' // mockito 4's version doesn't work with Java 21
+  }
+  testImplementation 'net.bytebuddy:byte-buddy:1.15.1' // Use the latest available version
   testImplementation 'org.mockito:mockito-inline:4.11.0'
 }
 


### PR DESCRIPTION
Adding Java version 21 to the testing matrix to ensure the SDK operates as expected in newer version of Java