### PR TITLE
feat: Async configuration handling using CompletableFutures and other config refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.1.1-SNAPSHOT'
+version = '3.2.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.1.0-SNAPSHOT'
+version = '3.1.1-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -127,9 +127,6 @@ public class BaseEppoClient {
     // Save SDK name and version to include in logger metadata
     this.sdkName = sdkName;
     this.sdkVersion = sdkVersion;
-
-    // TODO: caching initialization (such as setting an API-key-specific prefix
-    //       will probably involve passing in configurationStore to the constructor
   }
 
   private EppoHttpClient buildHttpClient(

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -26,7 +26,7 @@ public class BaseEppoClient {
   protected static final String DEFAULT_HOST = "https://fscdn.eppo.cloud";
   protected final ConfigurationRequestor requestor;
 
-  private final ConfigurationStore configurationStore;
+  private final IConfigurationStore configurationStore;
   private final AssignmentLogger assignmentLogger;
   private final BanditLogger banditLogger;
   private final String sdkName;

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,10 +112,12 @@ public class BaseEppoClient {
   }
 
   protected void loadConfiguration() {
-    requestor.load();
+    requestor.fetchAndSaveFromRemote();
   }
 
-  // TODO: async way to refresh for android
+  protected CompletableFuture<Void> loadConfigurationAsync() {
+    return requestor.fetchAndSaveFromRemoteAsync();
+  }
 
   protected EppoValue getTypedAssignment(
       String flagKey,

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -94,7 +94,7 @@ public class BaseEppoClient {
       IConfigurationStore configurationStore,
       boolean isGracefulMode,
       boolean expectObfuscatedConfig,
-      Configuration initialConfiguration) {
+      CompletableFuture<Configuration> initialConfiguration) {
 
     if (apiKey == null) {
       throw new IllegalArgumentException("Unable to initialize Eppo SDK due to missing API key");
@@ -109,7 +109,7 @@ public class BaseEppoClient {
 
     EppoHttpClient httpClient = buildHttpClient(host, apiKey, sdkName, sdkVersion);
     if (configurationStore == null) {
-      this.configurationStore = new ConfigurationStore(initialConfiguration);
+      this.configurationStore = new ConfigurationStore();
     } else {
       this.configurationStore = configurationStore;
     }
@@ -117,6 +117,10 @@ public class BaseEppoClient {
     // For now, the configuration is only obfuscated for Android clients
     requestor =
         new ConfigurationRequestor(this.configurationStore, httpClient, expectObfuscatedConfig);
+    if (initialConfiguration != null) {
+      requestor.setInitialConfiguration(initialConfiguration);
+    }
+
     this.assignmentLogger = assignmentLogger;
     this.banditLogger = banditLogger;
     this.isGracefulMode = isGracefulMode;

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -55,6 +55,7 @@ public class BaseEppoClient {
         host,
         assignmentLogger,
         banditLogger,
+        null,
         isGracefulMode,
         expectObfuscatedConfig,
         null);
@@ -67,6 +68,30 @@ public class BaseEppoClient {
       String host,
       AssignmentLogger assignmentLogger,
       BanditLogger banditLogger,
+      IConfigurationStore configurationStore,
+      boolean isGracefulMode,
+      boolean expectObfuscatedConfig) {
+    this(
+        apiKey,
+        sdkName,
+        sdkVersion,
+        host,
+        assignmentLogger,
+        banditLogger,
+        configurationStore,
+        isGracefulMode,
+        expectObfuscatedConfig,
+        null);
+  }
+
+  protected BaseEppoClient(
+      String apiKey,
+      String sdkName,
+      String sdkVersion,
+      String host,
+      AssignmentLogger assignmentLogger,
+      BanditLogger banditLogger,
+      IConfigurationStore configurationStore,
       boolean isGracefulMode,
       boolean expectObfuscatedConfig,
       Configuration initialConfiguration) {
@@ -83,10 +108,15 @@ public class BaseEppoClient {
     }
 
     EppoHttpClient httpClient = buildHttpClient(host, apiKey, sdkName, sdkVersion);
-    this.configurationStore = new ConfigurationStore(initialConfiguration);
+    if (configurationStore == null) {
+      this.configurationStore = new ConfigurationStore(initialConfiguration);
+    } else {
+      this.configurationStore = configurationStore;
+    }
 
     // For now, the configuration is only obfuscated for Android clients
-    requestor = new ConfigurationRequestor(configurationStore, httpClient, expectObfuscatedConfig);
+    requestor =
+        new ConfigurationRequestor(this.configurationStore, httpClient, expectObfuscatedConfig);
     this.assignmentLogger = assignmentLogger;
     this.banditLogger = banditLogger;
     this.isGracefulMode = isGracefulMode;

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -12,11 +12,11 @@ public class ConfigurationRequestor {
   private static final Logger log = LoggerFactory.getLogger(ConfigurationRequestor.class);
 
   private final EppoHttpClient client;
-  private final ConfigurationStore configurationStore;
+  private final IConfigurationStore configurationStore;
   private final boolean expectObfuscatedConfig;
 
   public ConfigurationRequestor(
-      ConfigurationStore configurationStore,
+      IConfigurationStore configurationStore,
       EppoHttpClient client,
       boolean expectObfuscatedConfig) {
     this.configurationStore = configurationStore;

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -1,16 +1,32 @@
 package cloud.eppo;
 
 import cloud.eppo.api.Configuration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // TODO: handle bandit stuff
 public class ConfigurationRequestor {
   private static final Logger log = LoggerFactory.getLogger(ConfigurationRequestor.class);
+  private static final String FLAG_CONFIG_PATH = "/api/flag-config/v1/config";
+  private static final String BANDIT_PARAMETER_PATH = "/api/flag-config/v1/bandits";
 
   private final EppoHttpClient client;
   private final IConfigurationStore configurationStore;
   private final boolean expectObfuscatedConfig;
+  private final boolean supportBandits;
+
+  public ConfigurationRequestor(
+      IConfigurationStore configurationStore,
+      EppoHttpClient client,
+      boolean expectObfuscatedConfig,
+      boolean supportBandits) {
+    this.configurationStore = configurationStore;
+    this.client = client;
+    this.expectObfuscatedConfig = expectObfuscatedConfig;
+    this.supportBandits = supportBandits;
+  }
 
   public ConfigurationRequestor(
       IConfigurationStore configurationStore,
@@ -19,24 +35,61 @@ public class ConfigurationRequestor {
     this.configurationStore = configurationStore;
     this.client = client;
     this.expectObfuscatedConfig = expectObfuscatedConfig;
+    this.supportBandits = true;
   }
 
-  // TODO: async loading for android
-  public void load() {
-    // Grab hold of the last configuration in case its bandit models are useful
+  /** Loads configuration synchronously from the API server. */
+  void fetchAndSaveFromRemote() {
+    log.debug("Fetching configuration");
+
+    // Reuse the `lastConfig` as its bandits may be useful
     Configuration lastConfig = configurationStore.getConfiguration();
 
-    log.debug("Fetching configuration");
-    byte[] flagConfigurationJsonBytes = client.get("/api/flag-config/v1/config");
+    byte[] flagConfigurationJsonBytes = client.get(FLAG_CONFIG_PATH);
     Configuration.Builder configBuilder =
         new Configuration.Builder(flagConfigurationJsonBytes, expectObfuscatedConfig)
             .banditParametersFromConfig(lastConfig);
 
-    if (configBuilder.requiresBanditModels()) {
-      byte[] banditParametersJsonBytes = client.get("/api/flag-config/v1/bandits");
+    if (supportBandits && configBuilder.requiresBanditModels()) {
+      byte[] banditParametersJsonBytes = client.get(BANDIT_PARAMETER_PATH);
       configBuilder.banditParameters(banditParametersJsonBytes);
     }
 
     configurationStore.setConfiguration(configBuilder.build());
+  }
+
+  /** Loads configuration asynchronously from the API server, off-thread. */
+  CompletableFuture<Void> fetchAndSaveFromRemoteAsync() {
+    log.debug("Fetching configuration from API server");
+    final Configuration lastConfig = configurationStore.getConfiguration();
+
+    return client
+        .getAsync(FLAG_CONFIG_PATH)
+        .thenApply(
+            flagConfigJsonBytes -> {
+              Configuration.Builder configBuilder =
+                  new Configuration.Builder(flagConfigJsonBytes, expectObfuscatedConfig)
+                      .banditParametersFromConfig(
+                          lastConfig); // possibly reuse last bandit models loaded for efficiency.
+
+              if (supportBandits && configBuilder.requiresBanditModels()) {
+                byte[] banditParametersJsonBytes;
+                try {
+                  banditParametersJsonBytes = client.getAsync(BANDIT_PARAMETER_PATH).get();
+                } catch (InterruptedException | ExecutionException e) {
+                  log.error("Error fetching from remote: " + e.getMessage());
+                  throw new RuntimeException(e);
+                }
+                if (banditParametersJsonBytes != null) {
+                  configBuilder.banditParameters(banditParametersJsonBytes);
+                }
+              }
+              return configBuilder.build();
+            })
+        .thenApply(
+            configuration -> {
+              configurationStore.setConfiguration(configuration);
+              return null;
+            });
   }
 }

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -6,7 +6,6 @@ import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// TODO: handle bandit stuff
 public class ConfigurationRequestor {
   private static final Logger log = LoggerFactory.getLogger(ConfigurationRequestor.class);
   private static final String FLAG_CONFIG_PATH = "/api/flag-config/v1/config";

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -57,11 +57,13 @@ public class ConfigurationRequestor {
         configurationFuture.thenAccept(
             (config) -> {
               synchronized (configurationStore) {
-                // Don't clobber an actual fetch.
                 if (config == null) {
                   log.debug("Initial configuration future returned null");
-                } else if (remoteFetchFuture != null && remoteFetchFuture.isDone()) {
-                  log.debug("Fetch beat the initial config; not clobbering");
+                } else if (remoteFetchFuture != null
+                    && remoteFetchFuture.isDone()
+                    && !remoteFetchFuture.isCompletedExceptionally()) {
+                  // Don't clobber a successful fetch.
+                  log.debug("Fetch successfully beat the initial config; not clobbering");
                 } else {
                   log.debug("saving initial configuration");
                   configurationStore.saveConfiguration(config);

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -1,6 +1,8 @@
 package cloud.eppo;
 
 import java.io.IOException;
+
+import cloud.eppo.api.Configuration;
 import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -55,7 +55,7 @@ public class ConfigurationRequestor {
       configBuilder.banditParameters(banditParametersJsonBytes);
     }
 
-    configurationStore.setConfiguration(configBuilder.build());
+    configurationStore.saveConfiguration(configBuilder.build());
   }
 
   /** Loads configuration asynchronously from the API server, off-thread. */
@@ -88,7 +88,7 @@ public class ConfigurationRequestor {
             })
         .thenApply(
             configuration -> {
-              configurationStore.setConfiguration(configuration);
+              configurationStore.saveConfiguration(configuration);
               return null;
             });
   }

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -1,8 +1,7 @@
 package cloud.eppo;
 
-import java.io.IOException;
-
 import cloud.eppo.api.Configuration;
+import java.io.IOException;
 import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -81,7 +81,7 @@ public class ConfigurationRequestor {
 
     byte[] flagConfigurationJsonBytes = client.get(FLAG_CONFIG_PATH);
     Configuration.Builder configBuilder =
-        new Configuration.Builder(flagConfigurationJsonBytes, expectObfuscatedConfig)
+        Configuration.builder(flagConfigurationJsonBytes, expectObfuscatedConfig)
             .banditParametersFromConfig(lastConfig);
 
     if (supportBandits && configBuilder.requiresUpdatedBanditModels()) {
@@ -110,7 +110,7 @@ public class ConfigurationRequestor {
                 flagConfigJsonBytes -> {
                   synchronized (this) {
                     Configuration.Builder configBuilder =
-                        new Configuration.Builder(flagConfigJsonBytes, expectObfuscatedConfig)
+                        Configuration.builder(flagConfigJsonBytes, expectObfuscatedConfig)
                             .banditParametersFromConfig(
                                 lastConfig); // possibly reuse last bandit models loaded.
 

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -3,6 +3,7 @@ package cloud.eppo;
 import cloud.eppo.api.Configuration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,8 +18,8 @@ public class ConfigurationRequestor {
   private final boolean supportBandits;
 
   public ConfigurationRequestor(
-      IConfigurationStore configurationStore,
-      EppoHttpClient client,
+      @NotNull IConfigurationStore configurationStore,
+      @NotNull EppoHttpClient client,
       boolean expectObfuscatedConfig,
       boolean supportBandits) {
     this.configurationStore = configurationStore;
@@ -28,8 +29,8 @@ public class ConfigurationRequestor {
   }
 
   public ConfigurationRequestor(
-      IConfigurationStore configurationStore,
-      EppoHttpClient client,
+      @NotNull IConfigurationStore configurationStore,
+      @NotNull EppoHttpClient client,
       boolean expectObfuscatedConfig) {
     this.configurationStore = configurationStore;
     this.client = client;

--- a/src/main/java/cloud/eppo/ConfigurationStore.java
+++ b/src/main/java/cloud/eppo/ConfigurationStore.java
@@ -7,12 +7,8 @@ public class ConfigurationStore implements IConfigurationStore {
 
   private volatile Configuration configuration;
 
-  public ConfigurationStore(final Configuration initialConfiguration) {
-    if (initialConfiguration != null) {
-      configuration = initialConfiguration;
-    } else {
-      configuration = Configuration.emptyConfig();
-    }
+  public ConfigurationStore() {
+    configuration = null;
   }
 
   public void saveConfiguration(@NotNull final Configuration configuration) {

--- a/src/main/java/cloud/eppo/ConfigurationStore.java
+++ b/src/main/java/cloud/eppo/ConfigurationStore.java
@@ -1,5 +1,6 @@
 package cloud.eppo;
 
+import cloud.eppo.api.Configuration;
 import org.jetbrains.annotations.NotNull;
 
 public class ConfigurationStore {

--- a/src/main/java/cloud/eppo/ConfigurationStore.java
+++ b/src/main/java/cloud/eppo/ConfigurationStore.java
@@ -3,7 +3,7 @@ package cloud.eppo;
 import cloud.eppo.api.Configuration;
 import org.jetbrains.annotations.NotNull;
 
-public class ConfigurationStore {
+public class ConfigurationStore implements IConfigurationStore {
 
   private volatile Configuration configuration;
 

--- a/src/main/java/cloud/eppo/ConfigurationStore.java
+++ b/src/main/java/cloud/eppo/ConfigurationStore.java
@@ -1,8 +1,10 @@
 package cloud.eppo;
 
 import cloud.eppo.api.Configuration;
+import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 
+/** Memory-only configuration store. */
 public class ConfigurationStore implements IConfigurationStore {
 
   private volatile Configuration configuration;
@@ -11,8 +13,9 @@ public class ConfigurationStore implements IConfigurationStore {
     configuration = null;
   }
 
-  public void saveConfiguration(@NotNull final Configuration configuration) {
+  public CompletableFuture<Void> saveConfiguration(@NotNull final Configuration configuration) {
     this.configuration = configuration;
+    return CompletableFuture.completedFuture(null);
   }
 
   public Configuration getConfiguration() {

--- a/src/main/java/cloud/eppo/ConfigurationStore.java
+++ b/src/main/java/cloud/eppo/ConfigurationStore.java
@@ -15,7 +15,7 @@ public class ConfigurationStore implements IConfigurationStore {
     }
   }
 
-  public void setConfiguration(@NotNull final Configuration configuration) {
+  public void saveConfiguration(@NotNull final Configuration configuration) {
     this.configuration = configuration;
   }
 

--- a/src/main/java/cloud/eppo/IConfigurationStore.java
+++ b/src/main/java/cloud/eppo/IConfigurationStore.java
@@ -3,7 +3,7 @@ package cloud.eppo;
 import cloud.eppo.api.Configuration;
 
 public interface IConfigurationStore {
-    Configuration getConfiguration();
+  Configuration getConfiguration();
 
-    void setConfiguration(Configuration build);
+  void setConfiguration(Configuration build);
 }

--- a/src/main/java/cloud/eppo/IConfigurationStore.java
+++ b/src/main/java/cloud/eppo/IConfigurationStore.java
@@ -5,5 +5,5 @@ import cloud.eppo.api.Configuration;
 public interface IConfigurationStore {
   Configuration getConfiguration();
 
-  void saveConfiguration(Configuration build);
+  void saveConfiguration(Configuration configuration);
 }

--- a/src/main/java/cloud/eppo/IConfigurationStore.java
+++ b/src/main/java/cloud/eppo/IConfigurationStore.java
@@ -5,5 +5,5 @@ import cloud.eppo.api.Configuration;
 public interface IConfigurationStore {
   Configuration getConfiguration();
 
-  void setConfiguration(Configuration build);
+  void saveConfiguration(Configuration build);
 }

--- a/src/main/java/cloud/eppo/IConfigurationStore.java
+++ b/src/main/java/cloud/eppo/IConfigurationStore.java
@@ -1,9 +1,14 @@
 package cloud.eppo;
 
 import cloud.eppo.api.Configuration;
+import java.util.concurrent.CompletableFuture;
 
+/**
+ * Common interface for extensions of this SDK to support caching and other strategies for
+ * persisting configuration data across sessions.
+ */
 public interface IConfigurationStore {
   Configuration getConfiguration();
 
-  void saveConfiguration(Configuration configuration);
+  CompletableFuture<Void> saveConfiguration(Configuration configuration);
 }

--- a/src/main/java/cloud/eppo/IConfigurationStore.java
+++ b/src/main/java/cloud/eppo/IConfigurationStore.java
@@ -1,0 +1,9 @@
+package cloud.eppo;
+
+import cloud.eppo.api.Configuration;
+
+public interface IConfigurationStore {
+    Configuration getConfiguration();
+
+    void setConfiguration(Configuration build);
+}

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -6,7 +6,6 @@ import cloud.eppo.ufc.dto.*;
 import cloud.eppo.ufc.dto.adapters.EppoModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -116,8 +115,12 @@ public class Configuration {
     return isConfigObfuscated;
   }
 
-  public String getFlagConfigJsonString() {
-    return new String(flagConfigJson, StandardCharsets.UTF_8);
+  public byte[] serializeFlagConfigToBytes() {
+    return flagConfigJson;
+  }
+
+  public byte[] serializeBanditParamsToBytes() {
+    return banditParamsJson;
   }
 
   /**

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -171,7 +171,7 @@ public class Configuration {
       }
     }
 
-    public boolean requiresBanditModels() {
+    public boolean requiresUpdatedBanditModels() {
       Set<String> neededModelVersions = referencedBanditModelVersion();
       return !loadedBanditModelVersions().containsAll(neededModelVersions);
     }

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -6,6 +6,7 @@ import cloud.eppo.ufc.dto.*;
 import cloud.eppo.ufc.dto.adapters.EppoModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -113,6 +114,10 @@ public class Configuration {
 
   public boolean isConfigObfuscated() {
     return isConfigObfuscated;
+  }
+
+  public String getFlagConfigJsonString() {
+    return new String(flagConfigJson, StandardCharsets.UTF_8);
   }
 
   /**

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -1,4 +1,4 @@
-package cloud.eppo;
+package cloud.eppo.api;
 
 import static cloud.eppo.Utils.getMD5Hex;
 
@@ -118,7 +118,7 @@ public class Configuration {
   /**
    * Builder to create the immutable config object.
    *
-   * @see cloud.eppo.Configuration for usage.
+   * @see Configuration for usage.
    */
   public static class Builder {
     private static final ObjectMapper mapper =

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -123,6 +123,9 @@ public class Configuration {
     return banditParamsJson;
   }
 
+  public static Builder builder(byte[] flagJson, boolean isConfigObfuscated) {
+    return new Builder(flagJson, isConfigObfuscated);
+  }
   /**
    * Builder to create the immutable config object.
    *

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -62,8 +62,11 @@ public class BaseEppoClientBanditTest {
             TEST_HOST,
             mockAssignmentLogger,
             mockBanditLogger,
+            null,
             false,
-            false);
+            false,
+            true,
+            null);
 
     eppoClient.loadConfiguration();
 
@@ -90,6 +93,7 @@ public class BaseEppoClientBanditTest {
             null,
             false,
             false,
+            true,
             initialConfig);
   }
 

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -84,6 +84,7 @@ public class BaseEppoClientBanditTest {
             TEST_HOST,
             mockAssignmentLogger,
             mockBanditLogger,
+            null,
             false,
             false,
             initialConfig);

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -78,7 +78,7 @@ public class BaseEppoClientBanditTest {
 
     CompletableFuture<Configuration> initialConfig =
         CompletableFuture.completedFuture(
-            new Configuration.Builder(initialFlagConfiguration, false)
+            Configuration.builder(initialFlagConfiguration.getBytes(), false)
                 .banditParameters(initialBanditParameters)
                 .build());
 

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -17,6 +17,7 @@ import cloud.eppo.logging.BanditLogger;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -72,10 +73,12 @@ public class BaseEppoClientBanditTest {
   private void initClientWithData(
       final String initialFlagConfiguration, final String initialBanditParameters) {
 
-    Configuration initialConfig =
-        new Configuration.Builder(initialFlagConfiguration, false)
-            .banditParameters(initialBanditParameters)
-            .build();
+    CompletableFuture<Configuration> initialConfig =
+        CompletableFuture.completedFuture(
+            new Configuration.Builder(initialFlagConfiguration, false)
+                .banditParameters(initialBanditParameters)
+                .build());
+
     eppoClient =
         new BaseEppoClient(
             DUMMY_BANDIT_API_KEY,

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import cloud.eppo.api.Attributes;
 import cloud.eppo.api.BanditActions;
 import cloud.eppo.api.BanditResult;
+import cloud.eppo.api.Configuration;
 import cloud.eppo.helpers.*;
 import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.AssignmentLogger;

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -263,25 +263,20 @@ public class BaseEppoClientTest {
   }
 
   @Test
-  public void testWithInitialConfigurationFuture() {
-    try {
-      CompletableFuture<Configuration> futureConfig = new CompletableFuture<>();
-      byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
+  public void testWithInitialConfigurationFuture() throws IOException {
+    CompletableFuture<Configuration> futureConfig = new CompletableFuture<>();
+    byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
 
-      initClientWithData(futureConfig, false, true);
+    initClientWithData(futureConfig, false, true);
 
-      double result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
-      assertEquals(0, result);
+    double result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
+    assertEquals(0, result);
 
-      // Now, complete the initial config future and check the value.
-      futureConfig.complete(Configuration.builder(flagConfig, false).build());
+    // Now, complete the initial config future and check the value.
+    futureConfig.complete(Configuration.builder(flagConfig, false).build());
 
-      result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
-      assertEquals(5, result);
-
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
+    assertEquals(5, result);
   }
 
   @Test

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import cloud.eppo.api.Attributes;
+import cloud.eppo.api.Configuration;
 import cloud.eppo.api.EppoValue;
 import cloud.eppo.helpers.AssignmentTestCase;
 import cloud.eppo.logging.Assignment;

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -72,6 +72,7 @@ public class BaseEppoClientTest {
             null,
             isGracefulMode,
             isConfigObfuscated,
+            true,
             initialFlagConfiguration);
   }
 
@@ -86,8 +87,11 @@ public class BaseEppoClientTest {
             TEST_HOST,
             mockAssignmentLogger,
             null,
+            null,
             isGracefulMode,
-            isConfigObfuscated);
+            isConfigObfuscated,
+            true,
+            null);
 
     eppoClient.loadConfiguration();
     log.info("Test client initialized");
@@ -332,33 +336,6 @@ public class BaseEppoClientTest {
 
     ArgumentCaptor<Assignment> assignmentLogCaptor = ArgumentCaptor.forClass(Assignment.class);
     verify(mockAssignmentLogger, times(1)).logAssignment(assignmentLogCaptor.capture());
-  }
-
-  @Test
-  public void testConfigurationStoreOverride() throws IOException {
-    IConfigurationStore mockConfigurationStore = mock(IConfigurationStore.class);
-
-    eppoClient =
-        new BaseEppoClient(
-            DUMMY_FLAG_API_KEY,
-            "java",
-            "3.0.0",
-            TEST_HOST,
-            mockAssignmentLogger,
-            null,
-            mockConfigurationStore,
-            true,
-            false);
-
-    double result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
-    assertEquals(0, result);
-
-    byte[] flagConfigBytes = FileUtils.readFileToByteArray(initialFlagConfigFile);
-    when(mockConfigurationStore.getConfiguration())
-        .thenReturn(new Configuration.Builder(flagConfigBytes, false).build());
-
-    result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
-    assertEquals(5, result);
   }
 
   // TODO: tests for the cache

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -241,7 +240,7 @@ public class BaseEppoClientTest {
   private CompletableFuture<Configuration> immediateConfigFuture(
       String config, boolean isObfuscated) {
     return CompletableFuture.completedFuture(
-        new Configuration.Builder(config, isObfuscated).build());
+        Configuration.builder(config.getBytes(), isObfuscated).build());
   }
 
   @Test
@@ -267,7 +266,7 @@ public class BaseEppoClientTest {
   public void testWithInitialConfigurationFuture() {
     try {
       CompletableFuture<Configuration> futureConfig = new CompletableFuture<>();
-      String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
+      byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
 
       initClientWithData(futureConfig, false, true);
 
@@ -275,7 +274,7 @@ public class BaseEppoClientTest {
       assertEquals(0, result);
 
       // Now, complete the initial config future and check the value.
-      futureConfig.complete(new Configuration.Builder(flagConfig, false).build());
+      futureConfig.complete(Configuration.builder(flagConfig, false).build());
 
       result = eppoClient.getDoubleAssignment("numeric_flag", "dummy subject", 0);
       assertEquals(5, result);

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -20,7 +20,7 @@ public class ConfigurationRequestorTest {
       new File("src/test/resources/static/boolean-flag.json");
 
   @Test
-  public void testInitialConfiguration() throws IOException {
+  public void testInitialConfigurationFuture() throws IOException {
     IConfigurationStore configStore = new ConfigurationStore();
     EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
 

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -28,13 +28,13 @@ public class ConfigurationRequestorTest {
         new ConfigurationRequestor(configStore, mockHttpClient, false, true);
 
     CompletableFuture<Configuration> futureConfig = new CompletableFuture<>();
-    String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
+    byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
 
     requestor.setInitialConfiguration(futureConfig);
 
     assertNull(configStore.getConfiguration());
 
-    futureConfig.complete(new Configuration.Builder(flagConfig, false).build());
+    futureConfig.complete(Configuration.builder(flagConfig, false).build());
 
     assertNotNull(configStore.getConfiguration());
     assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));

--- a/src/test/java/cloud/eppo/ProfileBaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/ProfileBaseEppoClientTest.java
@@ -42,8 +42,11 @@ public class ProfileBaseEppoClientTest {
             TEST_HOST,
             noOpAssignmentLogger,
             null,
+            null,
             false,
-            false);
+            false,
+            true,
+            null);
 
     eppoClient.loadConfiguration();
 

--- a/src/test/java/cloud/eppo/helpers/TestUtils.java
+++ b/src/test/java/cloud/eppo/helpers/TestUtils.java
@@ -1,13 +1,12 @@
 package cloud.eppo.helpers;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import cloud.eppo.BaseEppoClient;
 import cloud.eppo.EppoHttpClient;
-import cloud.eppo.EppoHttpClientRequestCallback;
 import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
 import okhttp3.*;
 
 public class TestUtils {
@@ -18,27 +17,12 @@ public class TestUtils {
     EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
 
     // Mock sync get
-    Response dummyResponse =
-        new Response.Builder()
-            // Used by test
-            .code(200)
-            .body(ResponseBody.create(responseBody, MediaType.get("application/json")))
-            // Below properties are required to build the Response (but unused)
-            .request(new Request.Builder().url(host).build())
-            .protocol(Protocol.HTTP_1_1)
-            .message("OK")
-            .build();
-    when(mockHttpClient.get(anyString())).thenReturn(dummyResponse);
+    when(mockHttpClient.get(anyString())).thenReturn(responseBody.getBytes());
 
     // Mock async get
-    doAnswer(
-            invocation -> {
-              EppoHttpClientRequestCallback callback = invocation.getArgument(1);
-              callback.onSuccess(responseBody);
-              return null; // doAnswer doesn't require a return value
-            })
-        .when(mockHttpClient)
-        .get(anyString(), any(EppoHttpClientRequestCallback.class));
+    CompletableFuture<byte[]> mockAsyncResponse = new CompletableFuture<>();
+    when(mockHttpClient.getAsync(anyString())).thenReturn(mockAsyncResponse);
+    mockAsyncResponse.complete(responseBody.getBytes());
 
     setBaseClientHttpClientOverrideField(mockHttpClient);
   }

--- a/src/test/resources/static/boolean-flag.json
+++ b/src/test/resources/static/boolean-flag.json
@@ -1,0 +1,33 @@
+{
+  "flags": {
+    "boolean_flag": {
+      "key": "boolean_flag",
+      "enabled": true,
+      "variationType": "NUMERIC",
+      "variations": {
+        "true": {
+          "key": "true",
+          "value": true
+        },
+        "false": {
+          "key": "false",
+          "value": false
+        }
+      },
+      "allocations": [
+        {
+          "key": "rollout",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "true",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    }
+  }
+}


### PR DESCRIPTION
## Motivation and Context
- Android is migrating to use the common SDK and has some additional requirements around asynchronous fetching, asynchronous initial configuration and resolving race conditions from config sources (cache vs remote API).

- The race condition between a cache load and a remote fetch only happens during the initialization of the `BaseEppoClient`. Specifically, when the client is created with an initial configuration and then the async `loadConfiguration` method is called. In this case, we don't want the cache load to clobber the fetched configuration as the fetched flags are always the latest. On subsequent calls to load (or loadAsync), we already have a reference to a `Configuration` in memory, so a cache-load attempt is not needed.

- The `IConfigurationStore` interface from the javascript common library is a robust interface capable of implementing multiple different config loading and caching strategies. Similar flexibility in the java common sdk is the goal; this change is a step towards it that will allow the additional complexities to be layered on.

- `CompletableFuture` gives a nice API to track done-ness without the need for atomics.

## Overview of changes
- Make `initialFlagConfig` parameter a `CompletableFuture<Configuration>`. This facilitates initializing the client with a config string as well as initial loads from cache.
- `CompletableFuture`s used in place of callback in `EppoHttpClient`, `ConfigurationRequestor`, etc.
- `IconfigurationStore` interface for extending cache and config storage strategies.
- moved `Configuration` to `api` package
- Async `fetchAndSaveFromRemote` method
- Initial Configuration setting is pushed to the `ConfigurationRequestor` so that it can be properly raced with async fetch calls
