### PR TITLE
feat: extract minimal assignment cache map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.4.0'
+version = '3.4.1-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.4.1-SNAPSHOT'
+version = '3.5.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {
@@ -55,18 +55,14 @@ spotless {
   ratchetFrom 'origin/main'
 
   format 'misc', {
-    // define the files to apply `misc` to
     target '*.gradle', '.gitattributes', '.gitignore'
 
-    // define the steps to apply to those files
     trimTrailingWhitespace()
-    indentWithSpaces(2) // or spaces. Takes an integer argument if you don't like 4
+    indentWithSpaces(2)
     endWithNewline()
   }
   java {
-    // apply a specific flavor of google-java-format
     googleJavaFormat('1.7')
-    // fix formatting of type annotations
     formatAnnotations()
   }
 }

--- a/src/main/java/cloud/eppo/api/AbstractAssignmentCache.java
+++ b/src/main/java/cloud/eppo/api/AbstractAssignmentCache.java
@@ -3,16 +3,42 @@ package cloud.eppo.api;
 import cloud.eppo.cache.AssignmentCacheEntry;
 import cloud.eppo.cache.AssignmentCacheKey;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link IAssignmentCache} implementation which takes a map to use as the underlying storage
  * mechanism.
  */
 public abstract class AbstractAssignmentCache implements IAssignmentCache {
-  protected final Map<String, String> delegate;
+
+  /** Minimal "map" implementation required to store cached assignment data. */
+  public interface CacheDelegate {
+    void put(String cacheKey, @NotNull String serializedEntry);
+
+    @Nullable String get(String cacheKey);
+  }
+
+  protected final CacheDelegate delegate;
+
+  protected AbstractAssignmentCache(final CacheDelegate delegate) {
+    this.delegate = delegate;
+  }
 
   protected AbstractAssignmentCache(final Map<String, String> delegate) {
-    this.delegate = delegate;
+    this(
+        new CacheDelegate() {
+
+          @Override
+          public void put(String cacheKey, @NotNull String serializedEntry) {
+            delegate.put(cacheKey, serializedEntry);
+          }
+
+          @Nullable @Override
+          public String get(String cacheKey) {
+            return delegate.get(cacheKey);
+          }
+        });
   }
 
   @Override
@@ -21,7 +47,7 @@ public abstract class AbstractAssignmentCache implements IAssignmentCache {
     return serializedEntry != null && serializedEntry.equals(entry.getValueKeyString());
   }
 
-  private String get(AssignmentCacheKey key) {
+  protected String get(AssignmentCacheKey key) {
     return delegate.get(key.toString());
   }
 

--- a/src/main/java/cloud/eppo/api/AbstractAssignmentCache.java
+++ b/src/main/java/cloud/eppo/api/AbstractAssignmentCache.java
@@ -47,7 +47,7 @@ public abstract class AbstractAssignmentCache implements IAssignmentCache {
     return serializedEntry != null && serializedEntry.equals(entry.getValueKeyString());
   }
 
-  protected String get(AssignmentCacheKey key) {
+  private String get(AssignmentCacheKey key) {
     return delegate.get(key.toString());
   }
 


### PR DESCRIPTION
## Motivation and Context
The `AbstractAssignmentCache` contains an implementation of the contract specificed in `IAssignmentCache` that the cache entry's value be used when determining the presence of a given cache entry. To allow specific cache implementations of `IAssignmentCache` to make use of this existing implementation, we need to either reimplement Map<String, String> to pass as a delegate, or extract a minimal interface for cache delegates.

## Overview of Changes
-`CacheDelegate` interface for non map-based implementations
- retain the `protected AbstractAssignmentCache(final Map<String, String> delegate)` constructor and wrap the map in a `CacheDelegate` implementation.