### PR TITLE
fix: Switch commons-codec Base64 to `java.util.Base64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.4.0'
+  implementation 'cloud.eppo:sdk-common-jvm:3.4.1'
 }
 ```
 
@@ -49,6 +49,6 @@ repositories {
 }
 
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.0.3-SNAPSHOT'
+  implementation 'cloud.eppo:sdk-common-jvm:3.4.2-SNAPSHOT'
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.4.0'
+version = '3.4.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -20,12 +20,8 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
-
   // For LRU and expiring maps
-  implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-
-  // For UFC DTOs
-  implementation 'commons-codec:commons-codec:1.17.1'
+  implementation 'org.apache.commons:commons-collections4:4.4'
   implementation 'org.slf4j:slf4j-api:2.0.16'
   testImplementation 'org.slf4j:slf4j-simple:2.0.16'
   testImplementation platform('org.junit:junit-bom:5.10.3')

--- a/src/main/java/cloud/eppo/Utils.java
+++ b/src/main/java/cloud/eppo/Utils.java
@@ -6,9 +6,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Locale;
-import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,14 +105,14 @@ public final class Utils {
     if (input == null) {
       return null;
     }
-    return Base64.encodeBase64String(input.getBytes(StandardCharsets.UTF_8));
+    return new String(Base64.getEncoder().encode(input.getBytes(StandardCharsets.UTF_8)));
   }
 
   public static String base64Decode(String input) {
     if (input == null) {
       return null;
     }
-    byte[] decodedBytes = Base64.decodeBase64(input);
+    byte[] decodedBytes = Base64.getDecoder().decode(input);
     if (decodedBytes.length == 0 && !input.isEmpty()) {
       throw new RuntimeException(
           "zero byte output from Base64; if not running on Android hardware be sure to use RobolectricTestRunner");


### PR DESCRIPTION
commons-codec is known to cause a plethora of issues on Android, as documented [in this blog post](https://blog.osom.info/2015/04/commons-codec-on-android.html).
Using `java.util.Base64` instead, allows us to work around that issue. This API has been introduced on Android SDK version 26.