### PR TITLE
chore: use established constants for URL and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.5.2'
+  implementation 'cloud.eppo:sdk-common-jvm:3.5.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.5.1'
+  implementation 'cloud.eppo:sdk-common-jvm:3.5.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.5.0'
+  implementation 'cloud.eppo:sdk-common-jvm:3.5.2'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.5.0'
+  implementation 'cloud.eppo:sdk-common-jvm:3.5.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.1'
+version = '3.5.1-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.2'
+version = '3.5.2-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.1-SNAPSHOT'
+version = '3.5.2'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.1-SNAPSHOT'
+version = '3.5.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -27,7 +27,6 @@ public class BaseEppoClient {
       new ObjectMapper()
           .registerModule(EppoModule.eppoModule()); // TODO: is this the best place for this?
 
-  protected static final String DEFAULT_HOST = "https://fscdn.eppo.cloud";
   protected final ConfigurationRequestor requestor;
 
   private final IConfigurationStore configurationStore;
@@ -76,7 +75,7 @@ public class BaseEppoClient {
           "Unable to initialize Eppo SDK due to missing SDK name or version");
     }
     if (host == null) {
-      host = DEFAULT_HOST;
+      host = Constants.DEFAULT_BASE_URL;
     }
 
     this.assignmentCache = assignmentCache;

--- a/src/main/java/cloud/eppo/Constants.java
+++ b/src/main/java/cloud/eppo/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
   public static final String RAC_ENDPOINT = "/randomized_assignment/v3/config";
 
   public static final String BANDIT_ENDPOINT = "/flag-config/v1/bandits";
+  public static final String FLAG_CONFIG_ENDPOINT = "/flag-config/v1/config";
 
   /** Caching Settings */
   public static final String EXPERIMENT_CONFIGURATION_CACHE_KEY = "experiment-configuration";

--- a/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientBanditTest.java
@@ -177,7 +177,7 @@ public class BaseEppoClientBanditTest {
     assertEquals("adidas", capturedBanditAssignment.getAction());
     assertEquals(0.099, capturedBanditAssignment.getActionProbability(), 0.0002);
     assertEquals(7.1, capturedBanditAssignment.getOptimalityGap(), 0.0002);
-    assertEquals("v123", capturedBanditAssignment.getModelVersion());
+    assertEquals("123", capturedBanditAssignment.getModelVersion());
 
     Attributes expectedSubjectNumericAttributes = new Attributes();
     expectedSubjectNumericAttributes.put("age", 25);

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -58,7 +58,7 @@ public class ConfigurationRequestorTest {
     String fetchedFlagConfig =
         FileUtils.readFileToString(differentFlagConfigFile, StandardCharsets.UTF_8);
 
-    when(mockHttpClient.getAsync("/api/flag-config/v1/config")).thenReturn(configFetchFuture);
+    when(mockHttpClient.getAsync("/flag-config/v1/config")).thenReturn(configFetchFuture);
 
     // Set initial config and verify that no config has been set yet.
     requestor.setInitialConfiguration(initialConfigFuture);
@@ -98,7 +98,7 @@ public class ConfigurationRequestorTest {
     String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
     CompletableFuture<byte[]> configFetchFuture = new CompletableFuture<>();
 
-    when(mockHttpClient.getAsync("/api/flag-config/v1/config")).thenReturn(configFetchFuture);
+    when(mockHttpClient.getAsync("/flag-config/v1/config")).thenReturn(configFetchFuture);
 
     // Set initial config and verify that no config has been set yet.
     requestor.setInitialConfiguration(initialConfigFuture);
@@ -135,7 +135,7 @@ public class ConfigurationRequestorTest {
     String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
     CompletableFuture<byte[]> configFetchFuture = new CompletableFuture<>();
 
-    when(mockHttpClient.getAsync("/api/flag-config/v1/config")).thenReturn(configFetchFuture);
+    when(mockHttpClient.getAsync("/flag-config/v1/config")).thenReturn(configFetchFuture);
 
     // Set initial config and verify that no config has been set yet.
     requestor.setInitialConfiguration(initialConfigFuture);


### PR DESCRIPTION
towards FF-3558
## Motivation and Context
Cross-SDK testing tools (scenario testing, benchmarking) require a consistent interface to building clients and one of the parameters passed is the `EPPO_BASE_URL`. Most, nearly all in fact, of the SDKs use a baseUrl of `https://fscdn.eppo.cloud/api` and endpoint constants of `/flag-config/v1/config` and `/flag-config/v1/bandits` for flag and bandit requests.

## Changes
- use established constants in `Constants.java`
- Move `/api` to baseUrl for consistency.
