### PR TITLE
fix: respect graceful mode during client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.5.2'
+  implementation 'cloud.eppo:sdk-common-jvm:3.5.3'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.5.0'
+  implementation 'cloud.eppo:sdk-common-jvm:3.5.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.2'
+version = '3.5.3'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.1-SNAPSHOT'
+version = '3.5.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -66,7 +66,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             isConfigObfuscated ? "android" : "java",
-            "3.5.1",
+            "100.1.0",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -86,7 +86,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             isConfigObfuscated ? "android" : "java",
-            "3.5.1",
+            "100.1.0",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -110,7 +110,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             isConfigObfuscated ? "android" : "java",
-            "3.5.1",
+            "100.1.0",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -132,7 +132,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             "java",
-            "3.5.1",
+            "100.1.0",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -436,7 +436,7 @@ public class BaseEppoClientTest {
     Map<String, String> expectedMeta = new HashMap<>();
     expectedMeta.put("obfuscated", "false");
     expectedMeta.put("sdkLanguage", "java");
-    expectedMeta.put("sdkLibVersion", "3.5.1");
+    expectedMeta.put("sdkLibVersion", "100.1.0");
 
     assertEquals(expectedMeta, capturedAssignment.getMetaData());
   }

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -305,6 +305,33 @@ public class BaseEppoClientTest {
   }
 
   @Test
+  public void testClientMakesDefaultAssignmentsAfterFailingToInitialize() {
+    // Set up bad HTTP response
+    mockHttpError();
+
+    // Initialize and no exception should be thrown.
+    assertDoesNotThrow(() -> initClient(true, false));
+
+    assertEquals("default", eppoClient.getStringAssignment("experiment1", "subject1", "default"));
+  }
+
+  @Test
+  public void testClientMakesDefaultAssignmentsAfterFailingToInitializeNonGracefulMode() {
+    // Set up bad HTTP response
+    mockHttpError();
+
+    // Initialize and no exception should be thrown.
+    try {
+      initClient(false, false);
+    } catch (RuntimeException e) {
+      // Expected
+      assertEquals("Intentional Error", e.getMessage());
+    } finally {
+      assertEquals("default", eppoClient.getStringAssignment("experiment1", "subject1", "default"));
+    }
+  }
+
+  @Test
   public void testNonGracefulInitializationFailure() {
     // Set up bad HTTP response
     mockHttpError();

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -66,7 +66,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             isConfigObfuscated ? "android" : "java",
-            "3.0.0",
+            "3.5.1",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -86,7 +86,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             isConfigObfuscated ? "android" : "java",
-            "3.0.0",
+            "3.5.1",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -110,7 +110,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             isConfigObfuscated ? "android" : "java",
-            "3.0.0",
+            "3.5.1",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -132,7 +132,7 @@ public class BaseEppoClientTest {
         new BaseEppoClient(
             DUMMY_FLAG_API_KEY,
             "java",
-            "3.0.0",
+            "3.5.1",
             TEST_HOST,
             mockAssignmentLogger,
             null,
@@ -436,7 +436,7 @@ public class BaseEppoClientTest {
     Map<String, String> expectedMeta = new HashMap<>();
     expectedMeta.put("obfuscated", "false");
     expectedMeta.put("sdkLanguage", "java");
-    expectedMeta.put("sdkLibVersion", "3.0.0");
+    expectedMeta.put("sdkLibVersion", "3.5.1");
 
     assertEquals(expectedMeta, capturedAssignment.getMetaData());
   }

--- a/src/test/java/cloud/eppo/helpers/TestUtils.java
+++ b/src/test/java/cloud/eppo/helpers/TestUtils.java
@@ -27,6 +27,21 @@ public class TestUtils {
     setBaseClientHttpClientOverrideField(mockHttpClient);
   }
 
+  public static void mockHttpError() {
+    // Create a mock instance of EppoHttpClient
+    EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+    // Mock sync get
+    when(mockHttpClient.get(anyString())).thenThrow(new RuntimeException("Intentional Error"));
+
+    // Mock async get
+    CompletableFuture<byte[]> mockAsyncResponse = new CompletableFuture<>();
+    when(mockHttpClient.getAsync(anyString())).thenReturn(mockAsyncResponse);
+    mockAsyncResponse.completeExceptionally(new RuntimeException("Intentional Error"));
+
+    setBaseClientHttpClientOverrideField(mockHttpClient);
+  }
+
   public static void setBaseClientHttpClientOverrideField(EppoHttpClient httpClient) {
     setBaseClientOverrideField("httpClientOverride", httpClient);
   }


### PR DESCRIPTION
🎟️ [linear](https://linear.app/eppo/issue/FF-3565/implement-graceful-mode-error-handling-in-initialization)
towards FF-3565

## Motivation and Context
The SDK will throw an unchecked exception upon initialization/loading configuration if it is unable to fetch over the network; this can result in applications crashing. 

## Changes
- log an error if an exception is thrown during configuration load, but only re-throw exceptions if `gracefulMode=false`

## How is this tested
- unit tests simulating error at the HTTP level
- Unit test continuing to attempt assignment after failed fetch.