### PR TITLE
fix: rollback api in baseUrl fix temporarily

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.5.3'
+version = '3.5.4'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/src/main/java/cloud/eppo/Constants.java
+++ b/src/main/java/cloud/eppo/Constants.java
@@ -3,7 +3,7 @@ package cloud.eppo;
 /** Constants Class */
 public class Constants {
   /** Base URL */
-  public static final String DEFAULT_BASE_URL = "https://fscdn.eppo.cloud/api";
+  public static final String DEFAULT_BASE_URL = "https://fscdn.eppo.cloud";
 
   public static final int REQUEST_TIMEOUT_MILLIS = 1000;
 
@@ -20,8 +20,8 @@ public class Constants {
   /** RAC settings */
   public static final String RAC_ENDPOINT = "/randomized_assignment/v3/config";
 
-  public static final String BANDIT_ENDPOINT = "/flag-config/v1/bandits";
-  public static final String FLAG_CONFIG_ENDPOINT = "/flag-config/v1/config";
+  public static final String BANDIT_ENDPOINT = "/api/flag-config/v1/bandits";
+  public static final String FLAG_CONFIG_ENDPOINT = "/api/flag-config/v1/config";
 
   /** Caching Settings */
   public static final String EXPERIMENT_CONFIGURATION_CACHE_KEY = "experiment-configuration";

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -58,7 +58,7 @@ public class ConfigurationRequestorTest {
     String fetchedFlagConfig =
         FileUtils.readFileToString(differentFlagConfigFile, StandardCharsets.UTF_8);
 
-    when(mockHttpClient.getAsync("/flag-config/v1/config")).thenReturn(configFetchFuture);
+    when(mockHttpClient.getAsync("/api/flag-config/v1/config")).thenReturn(configFetchFuture);
 
     // Set initial config and verify that no config has been set yet.
     requestor.setInitialConfiguration(initialConfigFuture);
@@ -98,7 +98,7 @@ public class ConfigurationRequestorTest {
     String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
     CompletableFuture<byte[]> configFetchFuture = new CompletableFuture<>();
 
-    when(mockHttpClient.getAsync("/flag-config/v1/config")).thenReturn(configFetchFuture);
+    when(mockHttpClient.getAsync("/api/flag-config/v1/config")).thenReturn(configFetchFuture);
 
     // Set initial config and verify that no config has been set yet.
     requestor.setInitialConfiguration(initialConfigFuture);
@@ -135,7 +135,7 @@ public class ConfigurationRequestorTest {
     String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
     CompletableFuture<byte[]> configFetchFuture = new CompletableFuture<>();
 
-    when(mockHttpClient.getAsync("/flag-config/v1/config")).thenReturn(configFetchFuture);
+    when(mockHttpClient.getAsync("/api/flag-config/v1/config")).thenReturn(configFetchFuture);
 
     // Set initial config and verify that no config has been set yet.
     requestor.setInitialConfiguration(initialConfigFuture);


### PR DESCRIPTION
## Motivation and Context
- Expecting a major version bugfix, the baseUrl change was merged but without a major version bump

## Changes
- move `api` back to the endpoints temporarily.

## Next Steps
- cut release 3.5.4
- mark v3.5.3 as bad?
- plan for api in baseUrl change to coincide with next major bump.