### PR TITLE
quality: parameterize sdk and test data branches

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**/*'
   push:
-    branches: [main, tp/**]
+    branches: [main]
 
   workflow_dispatch:
 

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -8,16 +8,6 @@ on:
     branches: [main, tp/**]
 
   workflow_dispatch:
-    inputs:
-      test_data_branch:
-        type: string
-        description: The branch in sdk-test-data to target for testcase files
-        required: false
-        default: main
-      sdk_branch:
-        type: string
-        description: The branch of the SDK to test
-        required: false
 
   workflow_call:
     inputs:

--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -5,12 +5,38 @@ on:
     paths:
       - '**/*'
   push:
-    branches: [main]
+    branches: [main, tp/**]
+
+  workflow_dispatch:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
+
+  workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
 
 env:
   ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
   ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
   CI: true
+  SDK_BRANCH: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH: ${{ inputs.test_data_branch || 'main' }}
 
 jobs:
   lint-test-sdk:
@@ -21,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: Eppo-exp/sdk-common-jdk
+          ref: ${{ env.SDK_BRANCH }}
           fetch-depth: 0
 
       - name: Set up JDK ${{ matrix.java-version }}
@@ -32,4 +60,4 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Run tests
-        run: make test
+        run: make test branchName=${TEST_DATA_BRANCH}

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-data:
 	mkdir -p ${tempDir}
 	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
 	cp -r ${gitDataDir}/ufc ${testDataDir}
-	rm ${testDataDir}/ufc/bandit-tests/*.dynamic-typing.json
+	rm -f ${testDataDir}/ufc/bandit-tests/*.dynamic-typing.json || true
 	rm -rf ${tempDir}
 
 .PHONY: test

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -40,11 +40,12 @@ public class BaseEppoClientTest {
   private static final Logger log = LoggerFactory.getLogger(BaseEppoClientTest.class);
   private static final String DUMMY_FLAG_API_KEY = "dummy-flags-api-key"; // Will load flags-v1
 
-  // Use the branch specified by env variable `TEST_DATA_BRANCH`.
+  // Use branch if specified by env variable `TEST_DATA_BRANCH`.
   private static final String TEST_BRANCH = System.getenv("TEST_DATA_BRANCH");
+  private static final String TEST_HOST_BASE =
+      "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile";
   private static final String TEST_HOST =
-      "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile/"
-          + (TEST_BRANCH != null ? "b/" + TEST_BRANCH : "");
+      TEST_HOST_BASE + (TEST_BRANCH != null ? "/b/" + TEST_BRANCH : "");
 
   private final ObjectMapper mapper =
       new ObjectMapper().registerModule(AssignmentTestCase.assignmentTestCaseModule());

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -39,8 +39,13 @@ import org.slf4j.LoggerFactory;
 public class BaseEppoClientTest {
   private static final Logger log = LoggerFactory.getLogger(BaseEppoClientTest.class);
   private static final String DUMMY_FLAG_API_KEY = "dummy-flags-api-key"; // Will load flags-v1
+
+  // Use the branch specified by env variable `TEST_DATA_BRANCH`.
+  private static final String TEST_BRANCH = System.getenv("TEST_DATA_BRANCH");
   private static final String TEST_HOST =
-      "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile";
+      "https://us-central1-eppo-qa.cloudfunctions.net/serveGitHubRacTestFile/"
+          + (TEST_BRANCH != null ? "b/" + TEST_BRANCH : "");
+
   private final ObjectMapper mapper =
       new ObjectMapper().registerModule(AssignmentTestCase.assignmentTestCaseModule());
 


### PR DESCRIPTION
🎟️ Fixes FF-3560 towards FF-3085

👯‍♂️ **Related PRs**

- [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/pull/83)
- [Update testing cloud function to accept branch name](https://github.com/Eppo-exp/eppo/pull/11418)


### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) has two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).