### PR TITLE
feat: polling in BaseEppoClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.6.1-SNAPSHOT'
+version = '3.7.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'cloud.eppo'
-version = '3.7.0-SNAPSHOT'
+version = '3.7.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -132,29 +132,30 @@ public class BaseEppoClient {
     }
   }
 
-  /**
-   * Start polling using the default interval and jitter.
-   */
+  /** Start polling using the default interval and jitter. */
   protected void startPolling() {
     startPolling(DEFAULT_POLLING_INTERVAL_MILLIS);
   }
 
   /**
    * Start polling using the provided polling interval and default jitter of 10%
+   *
    * @param pollingIntervalMs The base number of milliseconds to wait between configuration fetches.
    */
-  void startPolling(long pollingIntervalMs) {
+  protected void startPolling(long pollingIntervalMs) {
     startPolling(pollingIntervalMs, pollingIntervalMs / DEFAULT_JITTER_INTERVAL_RATIO);
   }
 
   /**
    * Start polling using the provided interval and jitter.
+   *
    * @param pollingIntervalMs The base number of milliseconds to wait between configuration fetches.
-   * @param pollingJitterMs The max number of milliseconds to offset each polling interval. The SDK selects a random
-   *                        number between 0 and pollingJitterMS to offset the polling interval by.
+   * @param pollingJitterMs The max number of milliseconds to offset each polling interval. The SDK
+   *     selects a random number between 0 and pollingJitterMS to offset the polling interval by.
    */
   protected void startPolling(long pollingIntervalMs, long pollingJitterMs) {
     stopPolling();
+    log.debug("Started polling at " + pollingIntervalMs + "," + pollingJitterMs);
 
     // Set up polling for UFC
     pollTimer = new Timer(true);

--- a/src/main/java/cloud/eppo/Constants.java
+++ b/src/main/java/cloud/eppo/Constants.java
@@ -2,33 +2,19 @@ package cloud.eppo;
 
 /** Constants Class */
 public class Constants {
-  /** Base URL */
+  /** API Endpoint Settings */
+  public static final String BANDIT_ENDPOINT = "/flag-config/v1/bandits";
+
+  public static final String FLAG_CONFIG_ENDPOINT = "/flag-config/v1/config";
   public static final String DEFAULT_BASE_URL = "https://fscdn.eppo.cloud/api";
 
   static String appendApiPathToHost(String host) {
     return host + "/api";
   }
 
-  public static final int REQUEST_TIMEOUT_MILLIS = 1000;
-
   /** Poller Settings */
   private static final long MILLISECOND_IN_ONE_SECOND = 1000;
 
-  public static final long TIME_INTERVAL_IN_MILLIS =
-      30 * MILLISECOND_IN_ONE_SECOND; // time interval
-  public static final long JITTER_INTERVAL_IN_MILLIS = 5 * MILLISECOND_IN_ONE_SECOND;
-
-  /** Cache Settings */
-  public static final int MAX_CACHE_ENTRIES = 1000;
-
-  /** RAC settings */
-  public static final String RAC_ENDPOINT = "/randomized_assignment/v3/config";
-
-  public static final String BANDIT_ENDPOINT = "/flag-config/v1/bandits";
-  public static final String FLAG_CONFIG_ENDPOINT = "/flag-config/v1/config";
-
-  /** Caching Settings */
-  public static final String EXPERIMENT_CONFIGURATION_CACHE_KEY = "experiment-configuration";
-
-  public static final String BANDIT_PARAMETER_CACHE_KEY = "bandit-parameter";
+  public static final long DEFAULT_POLLING_INTERVAL_MILLIS = 30 * MILLISECOND_IN_ONE_SECOND;
+  public static final long DEFAULT_JITTER_INTERVAL_RATIO = 10;
 }

--- a/src/main/java/cloud/eppo/FetchConfigurationTask.java
+++ b/src/main/java/cloud/eppo/FetchConfigurationTask.java
@@ -1,0 +1,37 @@
+package cloud.eppo;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetchConfigurationTask extends TimerTask {
+  private static final Logger log = LoggerFactory.getLogger(FetchConfigurationTask.class);
+  private final Runnable runnable;
+  private final Timer timer;
+  private final long intervalInMillis;
+  private final long jitterInMillis;
+
+  FetchConfigurationTask(
+      Runnable runnable, Timer timer, long intervalInMillis, long jitterInMillis) {
+    this.runnable = runnable;
+    this.timer = timer;
+    this.intervalInMillis = intervalInMillis;
+    this.jitterInMillis = jitterInMillis;
+  }
+
+  @Override
+  public void run() {
+    // TODO: retry on failed fetches
+    try {
+      runnable.run();
+    } catch (Exception e) {
+      log.error("[Eppo SDK] Error fetching experiment configuration", e);
+    }
+
+    long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
+    FetchConfigurationTask nextTask =
+        new FetchConfigurationTask(runnable, timer, intervalInMillis, jitterInMillis);
+    timer.schedule(nextTask, delay);
+  }
+}

--- a/src/main/java/cloud/eppo/FetchConfigurationTask.java
+++ b/src/main/java/cloud/eppo/FetchConfigurationTask.java
@@ -12,12 +12,19 @@ public class FetchConfigurationTask extends TimerTask {
   private final long intervalInMillis;
   private final long jitterInMillis;
 
-  FetchConfigurationTask(
+  public FetchConfigurationTask(
       Runnable runnable, Timer timer, long intervalInMillis, long jitterInMillis) {
     this.runnable = runnable;
     this.timer = timer;
     this.intervalInMillis = intervalInMillis;
     this.jitterInMillis = jitterInMillis;
+  }
+
+  public void scheduleNext() {
+    long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
+    FetchConfigurationTask nextTask =
+        new FetchConfigurationTask(runnable, timer, intervalInMillis, jitterInMillis);
+    timer.schedule(nextTask, delay);
   }
 
   @Override
@@ -28,10 +35,6 @@ public class FetchConfigurationTask extends TimerTask {
     } catch (Exception e) {
       log.error("[Eppo SDK] Error fetching experiment configuration", e);
     }
-
-    long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
-    FetchConfigurationTask nextTask =
-        new FetchConfigurationTask(runnable, timer, intervalInMillis, jitterInMillis);
-    timer.schedule(nextTask, delay);
+    scheduleNext();
   }
 }

--- a/src/main/java/cloud/eppo/FetchConfigurationTask.java
+++ b/src/main/java/cloud/eppo/FetchConfigurationTask.java
@@ -11,17 +11,25 @@ public class FetchConfigurationTask extends TimerTask {
   private final Timer timer;
   private final long intervalInMillis;
   private final long jitterInMillis;
+  private final long maxJitter;
 
   public FetchConfigurationTask(
       Runnable runnable, Timer timer, long intervalInMillis, long jitterInMillis) {
+    assert (jitterInMillis > 0);
+
     this.runnable = runnable;
     this.timer = timer;
     this.intervalInMillis = intervalInMillis;
+    this.maxJitter = intervalInMillis / 2;
     this.jitterInMillis = jitterInMillis;
   }
 
   public void scheduleNext() {
-    long delay = this.intervalInMillis - (long) (Math.random() * this.jitterInMillis);
+    // Limit jitter to half the interval. Also, prevents user-provided jitter from under-running the
+    // delay below 0.
+    long jitter =
+        Math.min(maxJitter, Math.round(Math.floor((Math.random() * this.jitterInMillis))));
+    long delay = this.intervalInMillis - jitter;
     FetchConfigurationTask nextTask =
         new FetchConfigurationTask(runnable, timer, intervalInMillis, jitterInMillis);
     timer.schedule(nextTask, delay);

--- a/src/test/java/cloud/eppo/helpers/TestUtils.java
+++ b/src/test/java/cloud/eppo/helpers/TestUtils.java
@@ -12,7 +12,7 @@ import okhttp3.*;
 public class TestUtils {
 
   @SuppressWarnings("SameParameterValue")
-  public static void mockHttpResponse(String host, String responseBody) {
+  public static EppoHttpClient mockHttpResponse(String responseBody) {
     // Create a mock instance of EppoHttpClient
     EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
 
@@ -25,6 +25,7 @@ public class TestUtils {
     mockAsyncResponse.complete(responseBody.getBytes());
 
     setBaseClientHttpClientOverrideField(mockHttpClient);
+    return mockHttpClient;
   }
 
   public static void mockHttpError() {


### PR DESCRIPTION
_Eppo Internal_
🎟️ Towards [FF-3876](https://linear.app/eppo/issue/FF-3876/[android-sdk]-allow-polling-for-configuration)

## Motivation and Context
The implementation for polling in the Java SDKs exists solely in the server SDK. A client has asked for the ability to poll within the Android SDK

## Changes Overview
Copy the polling implementation logic from the java server SDK's `EppoClient` up to the `BaseEppoClient`

- protected `startPolling` and `stopPolling` methods in the base client available to subclasses and tests.