### PR TITLE
fix: Catch timer exceptions

### DIFF
--- a/src/main/java/cloud/eppo/FetchConfigurationTask.java
+++ b/src/main/java/cloud/eppo/FetchConfigurationTask.java
@@ -32,7 +32,12 @@ public class FetchConfigurationTask extends TimerTask {
     long delay = this.intervalInMillis - jitter;
     FetchConfigurationTask nextTask =
         new FetchConfigurationTask(runnable, timer, intervalInMillis, jitterInMillis);
-    timer.schedule(nextTask, delay);
+
+    try {
+      timer.schedule(nextTask, delay);
+    } catch (IllegalStateException e) {
+      log.error("[Eppo SDK] Error scheduling next fetch task", e);
+    }
   }
 
   @Override

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -575,21 +575,18 @@ public class BaseEppoClientTest {
   public void testGracefulPolling() {
     Timer pollTimer = new Timer();
     final AtomicInteger callCount = new AtomicInteger(0);
-    Runnable runnerTask = new Runnable() {
-      @Override
-      public void run() {
-        callCount.incrementAndGet();
-      }
-    };
+    Runnable runnerTask =
+        new Runnable() {
+          @Override
+          public void run() {
+            callCount.incrementAndGet();
+          }
+        };
 
-    FetchConfigurationTask task = new FetchConfigurationTask(
-        runnerTask,
-        pollTimer,
-        50,
-        5
-    );
+    FetchConfigurationTask task = new FetchConfigurationTask(runnerTask, pollTimer, 50, 5);
 
-    // Trigger an unexpected state; the timer is cancelled but the FetchConfigurationTask attempts to schedule a runnable.
+    // Trigger an unexpected state; the timer is cancelled but the FetchConfigurationTask attempts
+    // to schedule a runnable.
     pollTimer.cancel();
     task.scheduleNext();
 
@@ -600,7 +597,6 @@ public class BaseEppoClientTest {
 
     // No exception to be thrown if illegal timer state is properly caught.
   }
-
 
   @Test
   public void testPolling() {

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -569,6 +570,37 @@ public class BaseEppoClientTest {
     ArgumentCaptor<Assignment> assignmentLogCaptor = ArgumentCaptor.forClass(Assignment.class);
     verify(mockAssignmentLogger, times(1)).logAssignment(assignmentLogCaptor.capture());
   }
+
+  @Test
+  public void testGracefulPolling() {
+    Timer pollTimer = new Timer();
+    final AtomicInteger callCount = new AtomicInteger(0);
+    Runnable runnerTask = new Runnable() {
+      @Override
+      public void run() {
+        callCount.incrementAndGet();
+      }
+    };
+
+    FetchConfigurationTask task = new FetchConfigurationTask(
+        runnerTask,
+        pollTimer,
+        50,
+        5
+    );
+
+    // Trigger an unexpected state; the timer is cancelled but the FetchConfigurationTask attempts to schedule a runnable.
+    pollTimer.cancel();
+    task.scheduleNext();
+
+    sleepUninterruptedly(50);
+
+    // If the Timer has been cancelled, FetchConfigurationTask doesn't  attempt to reschedule.
+    assertEquals(0, callCount.get());
+
+    // No exception to be thrown if illegal timer state is properly caught.
+  }
+
 
   @Test
   public void testPolling() {


### PR DESCRIPTION
fixes FF-3983

## Motivation and Context
https://github.com/Eppo-exp/android-sdk/actions/runs/13246564228/job/36981211128

From this test failure (and successful re-reruns), it appears that it's relatively probable for a timer to be pre-empted by the system or otherwise cancelled in way that causes the SDK code to attempt to use a cancelled timer

## Changes
Catch and log the illegal state