### PR TITLE
feat: `getConfig` and `getFlagType`

### DIFF
--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -203,7 +203,7 @@ public class BaseEppoClient {
     throwIfEmptyOrNull(flagKey, "flagKey must not be empty");
     throwIfEmptyOrNull(subjectKey, "subjectKey must not be empty");
 
-    Configuration config = configurationStore.getConfiguration();
+    Configuration config = getConfiguration();
 
     FlagConfig flag = config.getFlag(flagKey);
     if (flag == null) {
@@ -496,7 +496,7 @@ public class BaseEppoClient {
       Actions actions,
       String defaultValue) {
     BanditResult result = new BanditResult(defaultValue, null);
-    final Configuration config = configurationStore.getConfiguration();
+    final Configuration config = getConfiguration();
     try {
       String assignedVariation =
           getStringAssignment(
@@ -578,5 +578,9 @@ public class BaseEppoClient {
 
   public void setIsGracefulFailureMode(boolean isGracefulFailureMode) {
     this.isGracefulMode = isGracefulFailureMode;
+  }
+
+  public Configuration getConfiguration() {
+    return configurationStore.getConfiguration();
   }
 }

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -581,7 +581,7 @@ public class BaseEppoClient {
   }
 
   /**
-   * Gets the configuration object used by the EppoClient for assignment and bandit evaluation.
+   * Returns the configuration object used by the EppoClient for assignment and bandit evaluation.
    *
    * <p>The configuration object is for debugging (inspect the loaded config) and other advanced use
    * cases where flag metadata or a list of flag keys, for example, is required.

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -580,6 +580,18 @@ public class BaseEppoClient {
     this.isGracefulMode = isGracefulFailureMode;
   }
 
+  /**
+   * Gets the configuration object used by the EppoClient for assignment and bandit evaluation.
+   *
+   * <p>The configuration object is for debugging (inspect the loaded config) and other advanced use
+   * cases where flag metadata or a list of flag keys, for example, is required.
+   *
+   * <p>It is not recommended to use the list of keys to preload assignments as assignment
+   * computation also logs its use which will affect your metrics.
+   *
+   * @see <a href="https://docs.geteppo.com/sdks/best-practices/where-to-assign/">Where To
+   *     Assign</a> for more details.
+   */
   public Configuration getConfiguration() {
     return configurationStore.getConfiguration();
   }

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -121,6 +121,19 @@ public class Configuration {
     return flags.get(flagKeyForLookup);
   }
 
+  /**
+   * Gets the Variation Type for the specified flag if it exists, otherwise returns null.
+   *
+   * @return The Flag's variation type or null.
+   */
+  public @Nullable VariationType getFlagType(String flagKey) {
+    FlagConfig flag = getFlag(flagKey);
+    if (flag == null) {
+      return null;
+    }
+    return flag.getVariationType();
+  }
+
   public String banditKeyForVariation(String flagKey, String variationValue) {
     // Note: In practice this double loop should be quite quick as the number of bandits and bandit
     // variations will be small. Should this ever change, we can optimize things.

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -66,7 +66,8 @@ public class Configuration {
 
   private final byte[] banditParamsJson;
 
-  private Configuration(
+  /** Default visibility for tests. */
+  Configuration(
       Map<String, FlagConfig> flags,
       Map<String, BanditReference> banditReferences,
       Map<String, BanditParameters> bandits,
@@ -124,7 +125,7 @@ public class Configuration {
   /**
    * Gets the Variation Type for the specified flag if it exists, otherwise returns null.
    *
-   * @return The Flag's variation type or null.
+   * @return The flag's variation type or null.
    */
   public @Nullable VariationType getFlagType(String flagKey) {
     FlagConfig flag = getFlag(flagKey);

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -123,7 +123,7 @@ public class Configuration {
   }
 
   /**
-   * Gets the Variation Type for the specified flag if it exists, otherwise returns null.
+   * Returns the Variation Type for the specified flag if it exists, otherwise returns null.
    *
    * @return The flag's variation type or null.
    */

--- a/src/test/java/cloud/eppo/api/ConfigurationBuilderTest.java
+++ b/src/test/java/cloud/eppo/api/ConfigurationBuilderTest.java
@@ -1,11 +1,16 @@
 package cloud.eppo.api;
 
+import static cloud.eppo.Utils.getMD5Hex;
 import static org.junit.jupiter.api.Assertions.*;
 
+import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.FlagConfigResponse;
+import cloud.eppo.ufc.dto.VariationType;
 import cloud.eppo.ufc.dto.adapters.EppoModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class ConfigurationBuilderTest {
@@ -51,5 +56,67 @@ public class ConfigurationBuilderTest {
         mapper.readValue(serializedFlags, FlagConfigResponse.class);
 
     assertEquals(rehydratedConfig.getFormat(), FlagConfigResponse.Format.CLIENT);
+  }
+
+  @Test
+  public void getFlagType_shouldReturnCorrectType() {
+    // Create a flag config with a STRING variation type
+    FlagConfig flagConfig =
+        new FlagConfig(
+            "test-flag",
+            true,
+            1,
+            VariationType.STRING,
+            Collections.emptyMap(),
+            Collections.emptyList());
+
+    // Create configuration with this flag
+    Map<String, FlagConfig> flags = Collections.singletonMap("test-flag", flagConfig);
+    Configuration config =
+        new Configuration(flags, Collections.emptyMap(), Collections.emptyMap(), false, null, null);
+
+    // Test successful case
+    assertEquals(VariationType.STRING, config.getFlagType("test-flag"));
+
+    // Test non-existent flag
+    assertNull(config.getFlagType("non-existent-flag"));
+  }
+
+  @Test
+  public void getFlagType_withObfuscatedConfig_shouldReturnCorrectType() {
+    // Create a flag config with a NUMERIC variation type
+    FlagConfig flagConfig =
+        new FlagConfig(
+            "test-flag",
+            true,
+            1,
+            VariationType.NUMERIC,
+            Collections.emptyMap(),
+            Collections.emptyList());
+
+    // Create configuration with this flag using MD5 hash of the flag key
+    String hashedKey = getMD5Hex("test-flag");
+    Map<String, FlagConfig> flags = Collections.singletonMap(hashedKey, flagConfig);
+    Configuration config =
+        new Configuration(
+            flags,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            true, // obfuscated
+            null,
+            null);
+
+    // Test successful case with obfuscated config
+    assertEquals(VariationType.NUMERIC, config.getFlagType("test-flag"));
+
+    // Test non-existent flag
+    assertNull(config.getFlagType("non-existent-flag"));
+    assertNull(config.getFlagType(hashedKey));
+  }
+
+  @Test
+  public void getFlagType_withEmptyConfig_shouldReturnNull() {
+    Configuration config = Configuration.emptyConfig();
+    assertNull(config.getFlagType("any-flag"));
   }
 }


### PR DESCRIPTION
_Eppo Internal_
📜 [DD](https://www.notion.so/eppo/New-Java-SDK-methods-getConfiguration-and-getFlagType-19a49cc0114380709ff3e69f020650d8)
🎟️ Fixes FF-3454

## Motivation and Context
GlossGenius (and, likely other clients) integrate with the Eppo SDK in such a way that the type a given flag is not known at the time the assignment is requested from the SDK. In v2 of the SDK (Java server), `getAssignmentVariation` was available, [but removed in v3 to favour typed assignment returns.](https://eppo-group.slack.com/archives/C05FKKPDTJR/p1730229809171679?thread_ts=1730226618.797779&cid=C05FKKPDTJR) This method returned both the resulting value and its type. This information was used to convert the resulting value to the appropriate type for further processing.

There is a precedence for similar methods in other SDKs:

- the Rust SDK has [getAssignment](https://github.com/Eppo-exp/eppo-multiplatform/blob/cb8c6b441aaaf8ad2595caa76dddf9ea4097d84b/rust-sdk/src/client.rs#L112)
- The Ruby SDK exposes the [whole configuration object](https://github.com/Eppo-exp/eppo-multiplatform/blob/cb8c6b441aaaf8ad2595caa76dddf9ea4097d84b/ruby-sdk/lib/eppo_client/client.rb#L34) without an untyped getAssignment method
    - While Ruby/Python SDKs expose the configuration object, it’s not currently possible to programmatically get flag types from it. Configuration only has methods to get flags/bandits keys and to get serialized configuration
- Python also exposes the config through [get_configuration](https://github.com/Eppo-exp/eppo-multiplatform/blob/cb8c6b441aaaf8ad2595caa76dddf9ea4097d84b/python-sdk/src/client.rs#L428)
- JS has [getFlagConfigurations](https://github.com/Eppo-exp/js-sdk-common/blob/f6c3d4f2a1bb9e78538539fcfcd25ce1f44961a3/src/client/eppo-client.ts#L1154) which returns the raw DTO

The untyped assignment methods allow the assignment to be computed then converted by the developer into the correct type. The SDKs which expose the configuration require first a call to `getConfiguration().getFlagType(flagKey)`, then a call to the correct typed assignment method.

## Changes Overview
- expose the already existing `Configuration` object (which is immutable) via `getConfiguration`
- add a method to `getConfiguration` to return the variation type.