### PR TITLE
feat: onConfigurationChange

### DIFF
--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -578,6 +579,17 @@ public class BaseEppoClient {
 
   public void setIsGracefulFailureMode(boolean isGracefulFailureMode) {
     this.isGracefulMode = isGracefulFailureMode;
+  }
+
+  /**
+   * Subscribe to changes to the configuration.
+   *
+   * @param callback A function to be executed when the configuration changes.
+   * @return a Runnable which, when called unsubscribes the callback from configuration change
+   *     events.
+   */
+  public Runnable onConfigurationChange(Consumer<Void> callback) {
+    return requestor.onConfigurationChange(callback);
   }
 
   /**

--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -588,7 +588,7 @@ public class BaseEppoClient {
    * @return a Runnable which, when called unsubscribes the callback from configuration change
    *     events.
    */
-  public Runnable onConfigurationChange(Consumer<Void> callback) {
+  public Runnable onConfigurationChange(Consumer<Configuration> callback) {
     return requestor.onConfigurationChange(callback);
   }
 

--- a/src/main/java/cloud/eppo/ConfigurationRequestor.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestor.java
@@ -21,7 +21,7 @@ public class ConfigurationRequestor {
   private CompletableFuture<Boolean> configurationFuture = null;
   private boolean initialConfigSet = false;
 
-  private final CallbackManager<Void> configChangeManager = new CallbackManager<>();
+  private final CallbackManager<Configuration> configChangeManager = new CallbackManager<>();
 
   public ConfigurationRequestor(
       @NotNull IConfigurationStore configurationStore,
@@ -148,12 +148,12 @@ public class ConfigurationRequestor {
     return saveFuture.thenRun(
         () -> {
           synchronized (configChangeManager) {
-            configChangeManager.notifyCallbacks(null);
+            configChangeManager.notifyCallbacks(configuration);
           }
         });
   }
 
-  public Runnable onConfigurationChange(Consumer<Void> callback) {
+  public Runnable onConfigurationChange(Consumer<Configuration> callback) {
     return configChangeManager.subscribe(callback);
   }
 }

--- a/src/main/java/cloud/eppo/callback/CallbackManager.java
+++ b/src/main/java/cloud/eppo/callback/CallbackManager.java
@@ -1,5 +1,9 @@
 package cloud.eppo.callback;
 
+import cloud.eppo.ConfigurationRequestor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,6 +15,7 @@ import java.util.function.Consumer;
  * @param <T> The type of data that will be passed to the callbacks
  */
 public class CallbackManager<T> {
+  private static final Logger log = LoggerFactory.getLogger(CallbackManager.class);
   private final Map<String, Consumer<T>> subscribers;
 
   public CallbackManager() {
@@ -36,7 +41,13 @@ public class CallbackManager<T> {
    * @param data The data to pass to all callbacks
    */
   public void notify(T data) {
-    subscribers.values().forEach(callback -> callback.accept(data));
+    subscribers.values().forEach(callback ->{
+      try {
+        callback.accept(data);
+      } catch (Exception e) {
+        log.error("Eppo SDK: Error thrown by callback: {}", e.getMessage());
+      }
+    });
   }
 
   /** Remove all subscribers. */

--- a/src/main/java/cloud/eppo/callback/CallbackManager.java
+++ b/src/main/java/cloud/eppo/callback/CallbackManager.java
@@ -1,13 +1,11 @@
 package cloud.eppo.callback;
 
-import cloud.eppo.ConfigurationRequestor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A generic callback manager that allows registration and notification of callbacks.
@@ -40,14 +38,17 @@ public class CallbackManager<T> {
    *
    * @param data The data to pass to all callbacks
    */
-  public void notify(T data) {
-    subscribers.values().forEach(callback ->{
-      try {
-        callback.accept(data);
-      } catch (Exception e) {
-        log.error("Eppo SDK: Error thrown by callback: {}", e.getMessage());
-      }
-    });
+  public void notifyCallbacks(T data) {
+    subscribers
+        .values()
+        .forEach(
+            callback -> {
+              try {
+                callback.accept(data);
+              } catch (Exception e) {
+                log.error("Eppo SDK: Error thrown by callback: {}", e.getMessage());
+              }
+            });
   }
 
   /** Remove all subscribers. */

--- a/src/main/java/cloud/eppo/callback/CallbackManager.java
+++ b/src/main/java/cloud/eppo/callback/CallbackManager.java
@@ -1,0 +1,46 @@
+package cloud.eppo.callback;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * A generic callback manager that allows registration and notification of callbacks.
+ *
+ * @param <T> The type of data that will be passed to the callbacks
+ */
+public class CallbackManager<T> {
+  private final Map<String, Consumer<T>> subscribers;
+
+  public CallbackManager() {
+    this.subscribers = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Register a callback to be notified when events occur.
+   *
+   * @param callback The callback function to be called with event data
+   * @return A Runnable that can be called to unsubscribe the callback
+   */
+  public Runnable subscribe(Consumer<T> callback) {
+    String id = UUID.randomUUID().toString();
+    subscribers.put(id, callback);
+
+    return () -> subscribers.remove(id);
+  }
+
+  /**
+   * Notify all subscribers with the provided data.
+   *
+   * @param data The data to pass to all callbacks
+   */
+  public void notify(T data) {
+    subscribers.values().forEach(callback -> callback.accept(data));
+  }
+
+  /** Remove all subscribers. */
+  public void clear() {
+    subscribers.clear();
+  }
+}

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -2,6 +2,7 @@ package cloud.eppo;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,7 +11,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -159,5 +162,136 @@ public class ConfigurationRequestorTest {
     assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
 
     assertNull(configStore.getConfiguration().getFlag("boolean_flag"));
+  }
+
+  private ConfigurationStore mockConfigStore;
+  private EppoHttpClient mockHttpClient;
+  private ConfigurationRequestor requestor;
+
+  @BeforeEach
+  public void setup() {
+    mockConfigStore = mock(ConfigurationStore.class);
+    mockHttpClient = mock(EppoHttpClient.class);
+    requestor = new ConfigurationRequestor(mockConfigStore, mockHttpClient, false, true);
+  }
+
+  @Test
+  public void testConfigurationChangeListener() {
+    // Setup mock response
+    when(mockHttpClient.get(anyString())).thenReturn("{}".getBytes());
+    when(mockConfigStore.saveConfiguration(any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    AtomicInteger callCount = new AtomicInteger(0);
+
+    // Subscribe to configuration changes
+    Runnable unsubscribe = requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+    // Initial fetch should trigger the callback
+    requestor.fetchAndSaveFromRemote();
+    assertEquals(1, callCount.get());
+
+    // Another fetch should trigger the callback again
+    requestor.fetchAndSaveFromRemote();
+    assertEquals(2, callCount.get());
+
+    // Unsubscribe should prevent further callbacks
+    unsubscribe.run();
+    requestor.fetchAndSaveFromRemote();
+    assertEquals(2, callCount.get()); // Count should remain the same
+  }
+
+  @Test
+  public void testMultipleConfigurationChangeListeners() {
+    // Setup mock response
+    when(mockHttpClient.get(anyString())).thenReturn("{}".getBytes());
+    when(mockConfigStore.saveConfiguration(any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    AtomicInteger callCount1 = new AtomicInteger(0);
+    AtomicInteger callCount2 = new AtomicInteger(0);
+
+    // Subscribe multiple listeners
+    Runnable unsubscribe1 = requestor.onConfigurationChange(v -> callCount1.incrementAndGet());
+    Runnable unsubscribe2 = requestor.onConfigurationChange(v -> callCount2.incrementAndGet());
+
+    // Fetch should trigger both callbacks
+    requestor.fetchAndSaveFromRemote();
+    assertEquals(1, callCount1.get());
+    assertEquals(1, callCount2.get());
+
+    // Unsubscribe first listener
+    unsubscribe1.run();
+    requestor.fetchAndSaveFromRemote();
+    assertEquals(1, callCount1.get()); // Should not increase
+    assertEquals(2, callCount2.get()); // Should increase
+
+    // Unsubscribe second listener
+    unsubscribe2.run();
+    requestor.fetchAndSaveFromRemote();
+    assertEquals(1, callCount1.get()); // Should not increase
+    assertEquals(2, callCount2.get()); // Should not increase
+  }
+
+  @Test
+  public void testConfigurationChangeListenerIgnoresFailedFetch() {
+    // Setup mock response to simulate failure
+    when(mockHttpClient.get(anyString())).thenThrow(new RuntimeException("Fetch failed"));
+
+    AtomicInteger callCount = new AtomicInteger(0);
+    requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+    // Failed fetch should not trigger the callback
+    try {
+      requestor.fetchAndSaveFromRemote();
+    } catch (Exception e) {
+      // Expected
+    }
+    assertEquals(0, callCount.get());
+  }
+
+  @Test
+  public void testConfigurationChangeListenerIgnoresFailedSave() {
+    // Setup mock responses
+    when(mockHttpClient.get(anyString())).thenReturn("{}".getBytes());
+    when(mockConfigStore.saveConfiguration(any()))
+        .thenReturn(
+            CompletableFuture.supplyAsync(
+                () -> {
+                  throw new RuntimeException("Save failed");
+                }));
+
+    AtomicInteger callCount = new AtomicInteger(0);
+    requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+    // Failed save should not trigger the callback
+    try {
+      requestor.fetchAndSaveFromRemote();
+    } catch (RuntimeException e) {
+      // Pass
+    }
+    assertEquals(0, callCount.get());
+  }
+
+  @Test
+  public void testConfigurationChangeListenerAsyncSave() {
+    // Setup mock responses
+    when(mockHttpClient.getAsync(anyString()))
+        .thenReturn(CompletableFuture.completedFuture("{\"flags\":{}}".getBytes()));
+
+    CompletableFuture<Void> saveFuture = new CompletableFuture<>();
+    when(mockConfigStore.saveConfiguration(any())).thenReturn(saveFuture);
+
+    AtomicInteger callCount = new AtomicInteger(0);
+    requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+    // Start fetch
+    CompletableFuture<Void> fetch = requestor.fetchAndSaveFromRemoteAsync();
+    assertEquals(0, callCount.get()); // Callback should not be called yet
+
+    // Complete the save
+    saveFuture.complete(null);
+    fetch.join();
+    assertEquals(1, callCount.get()); // Callback should be called after save completes
   }
 }

--- a/src/test/java/cloud/eppo/callback/CallbackManagerTest.java
+++ b/src/test/java/cloud/eppo/callback/CallbackManagerTest.java
@@ -15,12 +15,12 @@ public class CallbackManagerTest {
 
     Runnable unsubscribe = CallbackManager.subscribe(received::add);
 
-    CallbackManager.notify("test message");
+    CallbackManager.notifyCallbacks("test message");
     assertEquals(1, received.size());
     assertEquals("test message", received.get(0));
 
     unsubscribe.run();
-    CallbackManager.notify("second message");
+    CallbackManager.notifyCallbacks("second message");
     assertEquals(1, received.size()); // Still 1 because we unsubscribed
   }
 
@@ -29,12 +29,14 @@ public class CallbackManagerTest {
     CallbackManager<String> manager = new CallbackManager<>();
     List<String> received = new ArrayList<>();
 
-    Runnable unsubscribe1 = manager.subscribe((s)-> {
-      throw new RuntimeException("test message");
-    });
+    Runnable unsubscribe1 =
+        manager.subscribe(
+            (s) -> {
+              throw new RuntimeException("test message");
+            });
     Runnable unsubscribe2 = manager.subscribe(received::add);
 
-    manager.notify("value");
+    manager.notifyCallbacks("value");
     assertEquals(1, received.size());
   }
 
@@ -47,7 +49,7 @@ public class CallbackManagerTest {
     manager.subscribe(received1::add);
     manager.subscribe(received2::add);
 
-    manager.notify(42);
+    manager.notifyCallbacks(42);
 
     assertEquals(1, received1.size());
     assertEquals(1, received2.size());
@@ -63,17 +65,17 @@ public class CallbackManagerTest {
     Runnable unsubscribe1 = manager.subscribe(received::add);
     Runnable unsubscribe2 = manager.subscribe(received::add);
 
-    manager.notify("value");
+    manager.notifyCallbacks("value");
     assertEquals(2, received.size());
 
     unsubscribe1.run();
-    manager.notify("value");
+    manager.notifyCallbacks("value");
 
     // Only one subscriber adds to the list
     assertEquals(3, received.size());
 
     unsubscribe2.run();
-    manager.notify("value");
+    manager.notifyCallbacks("value");
 
     // No change to the size after both subscribers are cancelled
     assertEquals(3, received.size());
@@ -88,12 +90,12 @@ public class CallbackManagerTest {
     manager.subscribe(received::add);
     manager.subscribe(received::add);
 
-    manager.notify("value");
+    manager.notifyCallbacks("value");
     assertEquals(2, received.size());
 
     manager.clear();
 
-    manager.notify("value");
+    manager.notifyCallbacks("value");
     assertEquals(2, received.size());
   }
 }

--- a/src/test/java/cloud/eppo/callback/CallbackManagerTest.java
+++ b/src/test/java/cloud/eppo/callback/CallbackManagerTest.java
@@ -25,15 +25,29 @@ public class CallbackManagerTest {
   }
 
   @Test
+  public void testThrowingCallback() {
+    CallbackManager<String> manager = new CallbackManager<>();
+    List<String> received = new ArrayList<>();
+
+    Runnable unsubscribe1 = manager.subscribe((s)-> {
+      throw new RuntimeException("test message");
+    });
+    Runnable unsubscribe2 = manager.subscribe(received::add);
+
+    manager.notify("value");
+    assertEquals(1, received.size());
+  }
+
+  @Test
   public void testMultipleSubscribers() {
-    CallbackManager<Integer> CallbackManager = new CallbackManager<>();
+    CallbackManager<Integer> manager = new CallbackManager<>();
     List<Integer> received1 = new ArrayList<>();
     List<Integer> received2 = new ArrayList<>();
 
-    CallbackManager.subscribe(received1::add);
-    CallbackManager.subscribe(received2::add);
+    manager.subscribe(received1::add);
+    manager.subscribe(received2::add);
 
-    CallbackManager.notify(42);
+    manager.notify(42);
 
     assertEquals(1, received1.size());
     assertEquals(1, received2.size());

--- a/src/test/java/cloud/eppo/callback/CallbackManagerTest.java
+++ b/src/test/java/cloud/eppo/callback/CallbackManagerTest.java
@@ -1,0 +1,85 @@
+package cloud.eppo.callback;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CallbackManagerTest {
+
+  @Test
+  public void testSubscribeAndNotify() {
+    CallbackManager<String> CallbackManager = new CallbackManager<>();
+    List<String> received = new ArrayList<>();
+
+    Runnable unsubscribe = CallbackManager.subscribe(received::add);
+
+    CallbackManager.notify("test message");
+    assertEquals(1, received.size());
+    assertEquals("test message", received.get(0));
+
+    unsubscribe.run();
+    CallbackManager.notify("second message");
+    assertEquals(1, received.size()); // Still 1 because we unsubscribed
+  }
+
+  @Test
+  public void testMultipleSubscribers() {
+    CallbackManager<Integer> CallbackManager = new CallbackManager<>();
+    List<Integer> received1 = new ArrayList<>();
+    List<Integer> received2 = new ArrayList<>();
+
+    CallbackManager.subscribe(received1::add);
+    CallbackManager.subscribe(received2::add);
+
+    CallbackManager.notify(42);
+
+    assertEquals(1, received1.size());
+    assertEquals(1, received2.size());
+    assertEquals(42, received1.get(0));
+    assertEquals(42, received2.get(0));
+  }
+
+  @Test
+  public void testUnsubscribe() {
+    CallbackManager<String> manager = new CallbackManager<>();
+    List<String> received = new ArrayList<>();
+
+    Runnable unsubscribe1 = manager.subscribe(received::add);
+    Runnable unsubscribe2 = manager.subscribe(received::add);
+
+    manager.notify("value");
+    assertEquals(2, received.size());
+
+    unsubscribe1.run();
+    manager.notify("value");
+
+    // Only one subscriber adds to the list
+    assertEquals(3, received.size());
+
+    unsubscribe2.run();
+    manager.notify("value");
+
+    // No change to the size after both subscribers are cancelled
+    assertEquals(3, received.size());
+  }
+
+  @Test
+  public void testClear() {
+    CallbackManager<String> manager = new CallbackManager<>();
+
+    List<String> received = new ArrayList<>();
+
+    manager.subscribe(received::add);
+    manager.subscribe(received::add);
+
+    manager.notify("value");
+    assertEquals(2, received.size());
+
+    manager.clear();
+
+    manager.notify("value");
+    assertEquals(2, received.size());
+  }
+}


### PR DESCRIPTION
Fixes FF-4107
[Notion Doc](https://www.notion.so/eppo/onConfigurationChanged-method-1af49cc0114380c6bd97f4ea1f780608?pvs=4)

## Motivation
Clients are looking for the ability to listen to changes to the confiugration

https://github.com/Eppo-exp/android-sdk/pull/159

## Change Description
- Callback manager to manage handles, cancelling and notifying callbacks
- centralized calls to `saveConfiguration` and included notifying callbacks
- new method on `EppoClient`: `onConfigurationChange`