### PR TITLE
[Draft] Android api 21 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.3'
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
+  // For base64 that works on on Android API 21
+  implementation "net.iharder:base64:2.3.8"
   // For LRU and expiring maps
   implementation 'org.apache.commons:commons-collections4:4.4'
   implementation 'org.slf4j:slf4j-api:2.0.17'

--- a/src/main/java/cloud/eppo/ConfigurationRequestorJava6.java
+++ b/src/main/java/cloud/eppo/ConfigurationRequestorJava6.java
@@ -1,0 +1,99 @@
+package cloud.eppo;
+
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import cloud.eppo.api.Configuration;
+import cloud.eppo.callback.CallbackManager;
+
+public class ConfigurationRequestorJava6 {
+  private static final Logger log = LoggerFactory.getLogger(ConfigurationRequestorJava6.class);
+  private enum ConfigState {
+    UNSET,
+    INITIAL_SET,
+    REMOTE_SET,
+    ;
+  }
+
+  private final EppoHttpClient client;
+  private final IConfigurationStoreJava6 configurationStoreJava6;
+  private final boolean expectObfuscatedConfig;
+  private final boolean supportBandits;
+
+  private final Object configStateLock = new Object();
+  private ConfigState configState;
+
+  private final CallbackManager<Configuration> configChangeManager = new CallbackManager<>();
+
+  public ConfigurationRequestorJava6(
+      @NotNull IConfigurationStoreJava6 configurationStoreJava6,
+      @NotNull EppoHttpClient client,
+      boolean expectObfuscatedConfig,
+      boolean supportBandits) {
+    this.configurationStoreJava6 = configurationStoreJava6;
+    this.client = client;
+    this.expectObfuscatedConfig = expectObfuscatedConfig;
+    this.supportBandits = supportBandits;
+
+    synchronized (configStateLock) {
+      configState = ConfigState.UNSET;
+    }
+  }
+
+  // Synchronously set the initial configuration.
+  public boolean setInitialConfigurationJava6(@NotNull Configuration configuration) {
+    synchronized (configStateLock) {
+      switch(configState) {
+        case UNSET:
+          configState = ConfigState.INITIAL_SET;
+          break;
+        case INITIAL_SET:
+          throw new IllegalStateException("Initial configuration has already been set");
+        case REMOTE_SET:
+          return false;
+      }
+    }
+
+    saveConfigurationAndNotifyJava6(configuration);
+    return true;
+  }
+
+  /** Loads configuration synchronously from the API server. */
+  void fetchAndSaveFromRemoteJava6() {
+    log.debug("Fetching configuration");
+
+    // Reuse the `lastConfig` as its bandits may be useful
+    Configuration lastConfig = configurationStoreJava6.getConfiguration();
+
+    byte[] flagConfigurationJsonBytes = client.getJava6(Constants.FLAG_CONFIG_ENDPOINT);
+    Configuration.Builder configBuilder =
+        Configuration.builder(flagConfigurationJsonBytes, expectObfuscatedConfig)
+            .banditParametersFromConfig(lastConfig);
+
+    if (supportBandits && configBuilder.requiresUpdatedBanditModels()) {
+      byte[] banditParametersJsonBytes = client.getJava6(Constants.BANDIT_ENDPOINT);
+      configBuilder.banditParameters(banditParametersJsonBytes);
+    }
+
+    synchronized (configStateLock) {
+      configState = ConfigState.REMOTE_SET;
+    }
+    saveConfigurationAndNotifyJava6(configBuilder.build());
+  }
+
+  private void saveConfigurationAndNotifyJava6(Configuration configuration) {
+    configurationStoreJava6.saveConfigurationJava6(configuration);
+    synchronized (configChangeManager) {
+      configChangeManager.notifyCallbacks(configuration);
+    }
+  }
+
+  public Runnable onConfigurationChange(Consumer<Configuration> callback) {
+    return configChangeManager.subscribe(callback);
+  }
+}

--- a/src/main/java/cloud/eppo/ConfigurationStoreJava6.java
+++ b/src/main/java/cloud/eppo/ConfigurationStoreJava6.java
@@ -1,0 +1,24 @@
+package cloud.eppo;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import cloud.eppo.api.Configuration;
+
+/** Memory-only configuration store. */
+public class ConfigurationStoreJava6 implements IConfigurationStoreJava6 {
+
+  // this is the fallback value if no configuration is provided (i.e. by fetch or initial config).
+  @NotNull private volatile Configuration configuration = Configuration.emptyConfig();
+
+  public ConfigurationStoreJava6() {}
+
+  public void saveConfigurationJava6(@NotNull final Configuration configuration) {
+    this.configuration = configuration;
+  }
+
+  @NotNull public Configuration getConfiguration() {
+    return configuration;
+  }
+}

--- a/src/main/java/cloud/eppo/IConfigurationStoreJava6.java
+++ b/src/main/java/cloud/eppo/IConfigurationStoreJava6.java
@@ -1,0 +1,18 @@
+package cloud.eppo;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import cloud.eppo.api.Configuration;
+
+/**
+ * Common interface for extensions of this SDK to support caching and other strategies for
+ * persisting configuration data across sessions.
+ */
+public interface IConfigurationStoreJava6 {
+  @NotNull Configuration getConfiguration();
+
+  void saveConfigurationJava6(Configuration configuration);
+}

--- a/src/main/java/cloud/eppo/Utils.java
+++ b/src/main/java/cloud/eppo/Utils.java
@@ -1,12 +1,15 @@
 package cloud.eppo;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import net.iharder.Base64;
+
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Base64;
 import java.util.Date;
 import java.util.Locale;
 import org.slf4j.Logger;
@@ -105,14 +108,21 @@ public final class Utils {
     if (input == null) {
       return null;
     }
-    return new String(Base64.getEncoder().encode(input.getBytes(StandardCharsets.UTF_8)));
+    return Base64.encodeBytes(input.getBytes(StandardCharsets.UTF_8));
   }
 
   public static String base64Decode(String input) {
     if (input == null) {
       return null;
     }
-    byte[] decodedBytes = Base64.getDecoder().decode(input);
+    byte[] decodedBytes;
+    try {
+      decodedBytes = Base64.decode(input);
+    } catch (IOException rethrow) {
+      // java.util.Base64 throws IllegalArgumentException
+      // on base64 format errors
+      throw new IllegalArgumentException(rethrow);
+    }
     if (decodedBytes.length == 0 && !input.isEmpty()) {
       throw new RuntimeException(
           "zero byte output from Base64; if not running on Android hardware be sure to use RobolectricTestRunner");

--- a/src/main/java/cloud/eppo/api/EppoValue.java
+++ b/src/main/java/cloud/eppo/api/EppoValue.java
@@ -101,7 +101,17 @@ public class EppoValue {
       case STRING:
         return this.stringValue;
       case ARRAY_OF_STRING:
-        return String.join(" ,", this.stringArrayValue);
+        if (this.stringArrayValue.isEmpty()) {
+          return "";
+        } else {
+          StringBuilder stringBuilder = new StringBuilder();
+          String delimiter = " ,";
+          for (String string : this.stringArrayValue) {
+            stringBuilder.append(string).append(delimiter);
+          }
+          stringBuilder.setLength(stringBuilder.length() - delimiter.length());
+          return stringBuilder.toString();
+        }
       case NULL:
         return "";
       default:

--- a/src/main/java/cloud/eppo/json/JacksonMapper.java
+++ b/src/main/java/cloud/eppo/json/JacksonMapper.java
@@ -1,0 +1,51 @@
+package cloud.eppo.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+import cloud.eppo.ufc.dto.adapters.EppoModule;
+
+public class JacksonMapper implements Mapper {
+  private static final ObjectMapper mapper =
+      new ObjectMapper().registerModule(EppoModule.eppoModule());
+  @Override
+  public MapperNode readTree(byte[] content) throws MapperException {
+    try {
+      JsonNode jsonNode = mapper.readTree(content);
+      return new JacksonMapperNode(jsonNode);
+    } catch (IOException e) {
+      throw new MapperException(e);
+    }
+  }
+
+  @Override
+  public MapperNode readTree(String content) throws MapperJsonProcessingException {
+    try {
+      JsonNode jsonNode = mapper.readTree(content);
+      return new JacksonMapperNode(jsonNode);
+    } catch (JsonProcessingException e) {
+      throw new MapperJsonProcessingException(e);
+    }
+  }
+
+  @Override
+  public <T> T readValue(byte[] src, Class<T> valueType) throws IOException {
+    try {
+      return mapper.readValue(src, valueType);
+    } catch (IOException e) {
+      throw new MapperException(e);
+    }
+  }
+
+  @Override
+  public byte[] writeValueAsBytes(MapperNode value) throws MapperException {
+    try {
+      return mapper.writeValueAsBytes(((JacksonMapperNode)value).getJsonNode());
+    } catch (IOException e) {
+      throw new MapperException(e);
+    }
+  }
+}

--- a/src/main/java/cloud/eppo/json/JacksonMapperNode.java
+++ b/src/main/java/cloud/eppo/json/JacksonMapperNode.java
@@ -1,0 +1,21 @@
+package cloud.eppo.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class JacksonMapperNode implements MapperNode {
+  private final JsonNode jsonNode;
+
+  public JacksonMapperNode(JsonNode jsonNode) {
+    this.jsonNode = jsonNode;
+  }
+
+  @Override
+  public void put(String fieldName, String v) {
+    ((ObjectNode) jsonNode).put(fieldName, v);
+  }
+
+  public JsonNode getJsonNode() {
+    return jsonNode;
+  }
+}

--- a/src/main/java/cloud/eppo/json/Mapper.java
+++ b/src/main/java/cloud/eppo/json/Mapper.java
@@ -1,0 +1,10 @@
+package cloud.eppo.json;
+
+import java.io.IOException;
+
+public interface Mapper {
+  MapperNode readTree(byte[] content) throws MapperException;
+  MapperNode readTree(String content) throws MapperJsonProcessingException;
+  <T> T readValue(byte[] src, Class<T> valueType) throws IOException;
+  byte[] writeValueAsBytes(MapperNode value) throws MapperException;
+}

--- a/src/main/java/cloud/eppo/json/MapperException.java
+++ b/src/main/java/cloud/eppo/json/MapperException.java
@@ -1,0 +1,15 @@
+package cloud.eppo.json;
+
+import java.io.IOException;
+
+public class MapperException extends IOException {
+  public MapperException(String message) {
+    super(message);
+  }
+  public MapperException(Throwable cause) {
+    super(cause);
+  }
+  public MapperException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/cloud/eppo/json/MapperJsonProcessingException.java
+++ b/src/main/java/cloud/eppo/json/MapperJsonProcessingException.java
@@ -1,0 +1,15 @@
+package cloud.eppo.json;
+
+public class MapperJsonProcessingException extends MapperException {
+  public MapperJsonProcessingException(String message) {
+    super(message);
+  }
+
+  public MapperJsonProcessingException(Throwable cause) {
+    super(cause);
+  }
+
+  public MapperJsonProcessingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/cloud/eppo/json/MapperNode.java
+++ b/src/main/java/cloud/eppo/json/MapperNode.java
@@ -1,0 +1,5 @@
+package cloud.eppo.json;
+
+public interface MapperNode {
+  void put(String fieldName, String v);
+}

--- a/src/test/java/cloud/eppo/ConfigurationRequestorJava6Test.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorJava6Test.java
@@ -1,0 +1,424 @@
+package cloud.eppo;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import net.bytebuddy.implementation.bytecode.Throw;
+
+import org.apache.commons.io.FileUtils;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import cloud.eppo.api.Configuration;
+
+public class ConfigurationRequestorJava6Test {
+    private final File initialFlagConfigFile =
+            new File("src/test/resources/static/initial-flag-config.json");
+    private final File differentFlagConfigFile =
+            new File("src/test/resources/static/boolean-flag.json");
+
+    @Test
+    public void testInitialConfigurationJava6() throws IOException {
+        IConfigurationStoreJava6 configStore = Mockito.spy(new ConfigurationStoreJava6());
+        EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+        ConfigurationRequestorJava6 requestor =
+                new ConfigurationRequestorJava6(configStore, mockHttpClient, false, true);
+
+        byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
+
+        // verify config is empty to start
+        assertTrue(configStore.getConfiguration().isEmpty());
+        Mockito.verify(configStore, Mockito.times(0)).saveConfigurationJava6(any());
+
+        boolean success = requestor.setInitialConfigurationJava6(Configuration.builder(flagConfig, false).build());
+        assertTrue(success);
+
+        assertFalse(configStore.getConfiguration().isEmpty());
+        Mockito.verify(configStore, Mockito.times(1)).saveConfigurationJava6(any());
+        assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
+    }
+
+    @Test
+    public void testInitialConfigurationJava6DoesntClobberFetch() throws Exception {
+        IConfigurationStoreJava6 configStore = Mockito.spy(new ConfigurationStoreJava6());
+        EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+        ConfigurationRequestorJava6 requestor =
+                new ConfigurationRequestorJava6(configStore, mockHttpClient, false, true);
+
+        byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
+        byte[] fetchedFlagConfig = FileUtils.readFileToByteArray(differentFlagConfigFile);
+
+        when(mockHttpClient.getJava6(Constants.FLAG_CONFIG_ENDPOINT)).thenReturn(fetchedFlagConfig);
+
+        assertTrue(configStore.getConfiguration().isEmpty());
+        Mockito.verify(configStore, Mockito.times(0)).saveConfigurationJava6(any());
+
+        // The initial config contains only one flag keyed `numeric_flag`. The fetch response has only
+        // one flag keyed
+        // `boolean_flag`. We make sure to complete the fetch future first to verify the cache load does
+        // not overwrite it.
+        requestor.fetchAndSaveFromRemoteJava6();
+
+        assertFalse(configStore.getConfiguration().isEmpty());
+        Mockito.verify(configStore, Mockito.times(1)).saveConfigurationJava6(any());
+
+        // set the initial config
+        boolean success = requestor.setInitialConfigurationJava6(Configuration.builder(flagConfig, false).build());
+        assertFalse(success);
+
+        // `numeric_flag` is only in the cache which should have been ignored.
+        assertNull(configStore.getConfiguration().getFlag("numeric_flag"));
+
+        // `boolean_flag` is available only from the fetch
+        assertNotNull(configStore.getConfiguration().getFlag("boolean_flag"));
+    }
+
+    @Test
+    public void testBrokenFetchDoesntClobberCache() throws Exception {
+        IConfigurationStoreJava6 configStore = Mockito.spy(new ConfigurationStoreJava6());
+        EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+        ConfigurationRequestorJava6 requestor =
+                new ConfigurationRequestorJava6(configStore, mockHttpClient, false, true);
+
+        byte[] flagConfig = FileUtils.readFileToByteArray(initialFlagConfigFile);
+
+        CountDownLatch httpCountDownLatch = new CountDownLatch(1);
+        BlockingQueue<Throwable> blockingQueue = new ArrayBlockingQueue<>(1);
+        when(mockHttpClient.getJava6(Constants.FLAG_CONFIG_ENDPOINT))
+                .thenAnswer((Answer<Void>) invocation -> {
+                    httpCountDownLatch.countDown();
+                    throw blockingQueue.take();
+                });
+
+        CountDownLatch requestorCountDownLatch = new CountDownLatch(1);
+        Thread requestorThread = new Thread(() -> {
+          try {
+            requestor.fetchAndSaveFromRemoteJava6();
+          } finally {
+            requestorCountDownLatch.countDown();
+          }
+        }, "testBrokenFetchDoesntClobberCache-requestorThread");
+        requestorThread.start();
+
+        // Make sure we made the HTTP request
+        assertTrue(httpCountDownLatch.await(1000, TimeUnit.MILLISECONDS));
+
+        // verify that no config has been set yet.
+        assertTrue(configStore.getConfiguration().isEmpty());
+        Mockito.verify(configStore, Mockito.times(0)).saveConfigurationJava6(any());
+
+        // Set initial config
+        requestor.setInitialConfigurationJava6(Configuration.builder(flagConfig, false).build());
+
+        // Error out the fetch
+        blockingQueue.put(new Exception("Intentional exception"));
+
+        // Make sure we finished processing the HTTP request
+        assertTrue(requestorCountDownLatch.await(1000, TimeUnit.MILLISECONDS));
+
+        assertFalse(configStore.getConfiguration().isEmpty());
+        Mockito.verify(configStore, Mockito.times(1)).saveConfigurationJava6(any());
+
+        // `numeric_flag` is only in the cache which should be available
+        assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
+
+        assertNull(configStore.getConfiguration().getFlag("boolean_flag"));
+    }
+
+    @Test
+    public void testCacheWritesAfterBrokenFetch() throws Exception {
+        IConfigurationStoreJava6 configStore = Mockito.spy(new ConfigurationStoreJava6());
+        EppoHttpClient mockHttpClient = mock(EppoHttpClient.class);
+
+        ConfigurationRequestorJava6 requestor =
+                new ConfigurationRequestorJava6(configStore, mockHttpClient, false, true);
+
+        String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
+
+        when(mockHttpClient.getJava6(Constants.FLAG_CONFIG_ENDPOINT))
+            .thenThrow(new RuntimeException("Intentional exception"));
+
+        // verify that no config has been set yet.
+        Mockito.verify(configStore, Mockito.times(0)).saveConfigurationJava6(any());
+
+        // default configuration is empty config.
+        assertTrue(configStore.getConfiguration().isEmpty());
+
+        // Fetch from remote with an error
+        try {
+          requestor.fetchAndSaveFromRemoteJava6();
+          fail("Expected RuntimeException");
+        } catch (RuntimeException ignored) {
+        }
+
+        // Set the initial config after the fetch throws an error.
+        boolean success = requestor.setInitialConfigurationJava6(new Configuration.Builder(flagConfig, false).build());
+        assertTrue(success);
+
+        // Verify that a configuration was saved by the requestor
+        Mockito.verify(configStore, Mockito.times(1)).saveConfigurationJava6(any());
+        assertFalse(configStore.getConfiguration().isEmpty());
+
+        // `numeric_flag` is only in the cache which should be available
+        assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
+
+        assertNull(configStore.getConfiguration().getFlag("boolean_flag"));
+    }
+
+    private static ServerSocket findServerSocket() {
+        int startPort = 8000;
+        int endPort = 1000;
+        int port = startPort;
+        ServerSocket serverSocket = null;
+        do {
+            try {
+                serverSocket = new ServerSocket(port);
+            } catch (IOException ignore) {
+                port++;
+            }
+        } while (serverSocket == null && port < endPort);
+        if (serverSocket == null) {
+            fail("Couldn't allocate ServerSocket between [" + startPort + ", " + endPort + ")");
+        }
+
+        return serverSocket;
+    }
+
+    @Test
+    public void testInterruptedFetchDoesNotClobberCache() throws Exception {
+        try (ServerSocket serverSocket = findServerSocket()) {
+          IConfigurationStoreJava6 configStore = Mockito.spy(new ConfigurationStoreJava6());
+          EppoHttpClient realHttpClient = new EppoHttpClient(
+            "http://localhost:" + serverSocket.getLocalPort(),
+            "apiKey",
+            "sdkName",
+            "sdkVersion"
+          );
+
+          ConfigurationRequestorJava6 requestor =
+              new ConfigurationRequestorJava6(configStore, realHttpClient, false, true);
+
+          // verify that no config has been set yet.
+          Mockito.verify(configStore, Mockito.times(0)).saveConfigurationJava6(any());
+
+          // default configuration is empty config.
+          assertTrue(configStore.getConfiguration().isEmpty());
+
+          CountDownLatch serverSocketCountDownLatch = new CountDownLatch(1);
+          Thread serverSocketThread = new Thread(() -> {
+            try {
+              Socket ignored = serverSocket.accept();
+              // intentionally don't close the ignored socket. It'll get closed
+              // when we close the ServerSocket
+              serverSocketCountDownLatch.countDown();
+            } catch (IOException ignored) {
+            }
+          }, "testInterruptedFetchDoesNotClobberCache-serverSocket");
+          serverSocketThread.start();
+
+          // Fetch from remote and later interrupt
+          CountDownLatch requestorCountDownLatch = new CountDownLatch(1);
+          AtomicBoolean expectExceptionAtomicBoolean = new AtomicBoolean();
+          AtomicReference<Throwable> unexpectedExceptionAtomicReference = new AtomicReference<>();
+          AtomicReference<Throwable> expectedExceptionAtomicReference = new AtomicReference<>();
+          Thread requestorThread = new Thread(() -> {
+            try {
+              requestor.fetchAndSaveFromRemoteJava6();
+            } catch (RuntimeException expected) {
+              if (expectExceptionAtomicBoolean.get()) {
+                expectedExceptionAtomicReference.set(expected);
+              } else {
+                unexpectedExceptionAtomicReference.set(expected);
+              }
+            }
+            requestorCountDownLatch.countDown();
+          }, "testInterruptedFetchDoesNotClobberCache-requestor");
+          requestorThread.start();
+
+          // Wait until we connect to the "server"
+          assertTrue(serverSocketCountDownLatch.await(1000, TimeUnit.MILLISECONDS));
+
+          String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
+
+          // Set the initial config.
+          boolean success = requestor.setInitialConfigurationJava6(new Configuration.Builder(flagConfig, false).build());
+          assertTrue(success);
+
+          // Verify that a configuration was saved by the requestor
+          Mockito.verify(configStore, Mockito.times(1)).saveConfigurationJava6(any());
+          assertFalse(configStore.getConfiguration().isEmpty());
+
+          expectExceptionAtomicBoolean.set(true);
+          requestorThread.interrupt();
+          assertTrue(requestorCountDownLatch.await(10000, TimeUnit.MILLISECONDS));
+          Throwable unexpectedException = unexpectedExceptionAtomicReference.get();
+          assertNull(unexpectedException);
+
+          Throwable expectedException = expectedExceptionAtomicReference.get();
+          assertNotNull(expectedException);
+          assertEquals(RuntimeException.class, expectedException.getClass());
+
+          // `numeric_flag` is only in the cache which should be available
+          assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
+
+          assertNull(configStore.getConfiguration().getFlag("boolean_flag"));
+        }
+    }
+
+    private ConfigurationStoreJava6 mockConfigStoreJava6;
+    private EppoHttpClient mockHttpClient;
+    private ConfigurationRequestorJava6 requestor;
+
+    @BeforeEach
+    public void setup() {
+        mockConfigStoreJava6 = mock(ConfigurationStoreJava6.class);
+        mockHttpClient = mock(EppoHttpClient.class);
+        requestor = new ConfigurationRequestorJava6(mockConfigStoreJava6, mockHttpClient, false, true);
+    }
+
+    @Test
+    public void testConfigurationChangeListener() throws IOException {
+        // Setup mock response
+        String flagConfig = FileUtils.readFileToString(initialFlagConfigFile, StandardCharsets.UTF_8);
+        when(mockHttpClient.get(anyString())).thenReturn(flagConfig.getBytes());
+
+        List<Configuration> receivedConfigs = new ArrayList<>();
+
+        // Subscribe to configuration changes
+        Runnable unsubscribe = requestor.onConfigurationChange(receivedConfigs::add);
+
+        // Initial fetch should trigger the callback
+        requestor.fetchAndSaveFromRemoteJava6();
+        assertEquals(1, receivedConfigs.size());
+
+        // Another fetch should trigger the callback again (fetches aren't optimized with eTag yet).
+        requestor.fetchAndSaveFromRemoteJava6();
+        assertEquals(2, receivedConfigs.size());
+
+        // Unsubscribe should prevent further callbacks
+        unsubscribe.run();
+        requestor.fetchAndSaveFromRemoteJava6();
+        assertEquals(2, receivedConfigs.size()); // Count should remain the same
+    }
+
+    @Test
+    public void testMultipleConfigurationChangeListeners() {
+        // Setup mock response
+        when(mockHttpClient.get(anyString())).thenReturn("{}".getBytes());
+
+        AtomicInteger callCount1 = new AtomicInteger(0);
+        AtomicInteger callCount2 = new AtomicInteger(0);
+
+        // Subscribe multiple listeners
+        Runnable unsubscribe1 = requestor.onConfigurationChange(v -> callCount1.incrementAndGet());
+        Runnable unsubscribe2 = requestor.onConfigurationChange(v -> callCount2.incrementAndGet());
+
+        // Fetch should trigger both callbacks
+        requestor.fetchAndSaveFromRemoteJava6();
+        assertEquals(1, callCount1.get());
+        assertEquals(1, callCount2.get());
+
+        // Unsubscribe first listener
+        unsubscribe1.run();
+        requestor.fetchAndSaveFromRemoteJava6();
+        assertEquals(1, callCount1.get()); // Should not increase
+        assertEquals(2, callCount2.get()); // Should increase
+
+        // Unsubscribe second listener
+        unsubscribe2.run();
+        requestor.fetchAndSaveFromRemoteJava6();
+        assertEquals(1, callCount1.get()); // Should not increase
+        assertEquals(2, callCount2.get()); // Should not increase
+    }
+
+    @Test
+    public void testConfigurationChangeListenerIgnoresFailedFetch() {
+        // Setup mock response to simulate failure
+        when(mockHttpClient.getJava6(anyString())).thenThrow(new RuntimeException("Fetch failed"));
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+        // Failed fetch should not trigger the callback
+        try {
+            requestor.fetchAndSaveFromRemoteJava6();
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            // Expected
+        }
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    public void testConfigurationChangeListenerIgnoresFailedSave() {
+        // Setup mock responses
+        when(mockHttpClient.get(anyString())).thenReturn("{}".getBytes());
+        doThrow(new RuntimeException("Save failed"))
+                .when(mockConfigStoreJava6).saveConfigurationJava6(any());
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+        // Failed save should not trigger the callback
+        try {
+            requestor.fetchAndSaveFromRemoteJava6();
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            // Pass
+        }
+        assertEquals(0, callCount.get());
+    }
+
+    @Test
+    public void testConfigurationChangeListenerSave() throws Exception {
+        BlockingQueue<byte[]> blockingQueue = new ArrayBlockingQueue<>(1);
+        // Setup mock responses
+        when(mockHttpClient.getJava6(anyString()))
+                .thenAnswer((Answer<byte[]>) invocation -> blockingQueue.take());
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        requestor.onConfigurationChange(v -> callCount.incrementAndGet());
+
+        // Start fetch
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Thread requestorThread = new Thread(() -> {
+            requestor.fetchAndSaveFromRemoteJava6();
+            countDownLatch.countDown();
+        }, "testConfigurationChangeListenerSave-requesterThread");
+        requestorThread.start();
+        assertEquals(0, callCount.get()); // Callback should not be called yet
+
+        // Complete the save
+        blockingQueue.put("{\"flags\":{}}".getBytes());
+        // Verify that the fetch completed
+        assertTrue(countDownLatch.await(1000, TimeUnit.MILLISECONDS));
+        assertEquals(1, callCount.get()); // Callback should be called after save completes
+    }
+}


### PR DESCRIPTION
This is a draft of implementations necessary to run on Android API 21. I haven't begun actually testing this on an Android API 21 emulator yet because I still need to work through backporting [android-sdk](https://github.com/Eppo-exp/android-sdk/), but this should give you an idea of the direction I'm going.

Major issues:
1. `String.join()` requires JDK8, so use StringBuilder instead
2. `java.util.Base64` requires JDK8, so use `net.iharder:base64` (Public Domain) instead
3. Operations using fork/join pools and `CompletableFuture` require JDK8, so create blocking versions of these classes, and have Android API 21 consumers handle concurrency manually.
4. `Jackson` requires JDK7, so put all Jackson consumption behind an interface so that Android API 21 can inject a `JSONObject`-based implementation.