### PR TITLE
Support serializing FlagConfigResponse

### DIFF
--- a/src/main/java/cloud/eppo/api/EppoValue.java
+++ b/src/main/java/cloud/eppo/api/EppoValue.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class EppoValue {
-  protected final EppoValueType type;
+  public final EppoValueType type;
   protected Boolean boolValue;
   protected Double doubleValue;
   protected String stringValue;

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/EppoModule.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/EppoModule.java
@@ -10,6 +10,7 @@ public class EppoModule {
   public static SimpleModule eppoModule() {
     SimpleModule module = new SimpleModule();
     module.addDeserializer(FlagConfigResponse.class, new FlagConfigResponseDeserializer());
+    module.addSerializer(FlagConfigResponse.class, new FlagConfigResponseSerializer());
     module.addDeserializer(
         BanditParametersResponse.class, new BanditParametersResponseDeserializer());
     module.addDeserializer(EppoValue.class, new EppoValueDeserializer());

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueSerializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueSerializer.java
@@ -18,20 +18,23 @@ public class EppoValueSerializer extends StdSerializer<EppoValue> {
   @Override
   public void serialize(EppoValue src, JsonGenerator jgen, SerializerProvider provider)
       throws IOException {
-    if (src.isBoolean()) {
-      jgen.writeBoolean(src.booleanValue());
-    }
-    if (src.isNumeric()) {
-      jgen.writeNumber(src.doubleValue());
-    }
-    if (src.isString()) {
-      jgen.writeString(src.stringValue());
-    }
-    if (src.isStringArray()) {
-      String[] arr = src.stringArrayValue().toArray(new String[0]);
-      jgen.writeArray(arr, 0, arr.length);
-    } else {
-      jgen.writeNull();
+    switch (src.type) {
+      case NULL:
+        jgen.writeNull();
+        break;
+      case BOOLEAN:
+        jgen.writeBoolean(src.booleanValue());
+        break;
+      case NUMBER:
+        jgen.writeNumber(src.doubleValue());
+        break;
+      case STRING:
+        jgen.writeString(src.stringValue());
+        break;
+      case ARRAY_OF_STRING:
+        String[] arr = src.stringArrayValue().toArray(new String[0]);
+        jgen.writeArray(arr, 0, arr.length);
+        break;
     }
   }
 }

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseDeserializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseDeserializer.java
@@ -135,7 +135,7 @@ public class FlagConfigResponseDeserializer extends StdDeserializer<FlagConfigRe
       Set<TargetingCondition> conditions = new HashSet<>();
       for (JsonNode conditionNode : ruleNode.get("conditions")) {
         String attribute = conditionNode.get("attribute").asText();
-        String operatorKey = conditionNode.get("operator").asText();
+        String operatorKey = conditionNode.get("operator").asText(null);
         OperatorType operator = OperatorType.fromString(operatorKey);
         if (operator == null) {
           log.warn("Unknown operator \"{}\"", operatorKey);

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseSerializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseSerializer.java
@@ -1,0 +1,260 @@
+package cloud.eppo.ufc.dto.adapters;
+
+import static cloud.eppo.Utils.getISODate;
+import static cloud.eppo.Utils.parseUtcISODateNode;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+import cloud.eppo.api.EppoValue;
+import cloud.eppo.model.ShardRange;
+import cloud.eppo.ufc.dto.Allocation;
+import cloud.eppo.ufc.dto.BanditFlagVariation;
+import cloud.eppo.ufc.dto.BanditReference;
+import cloud.eppo.ufc.dto.FlagConfig;
+import cloud.eppo.ufc.dto.FlagConfigResponse;
+import cloud.eppo.ufc.dto.OperatorType;
+import cloud.eppo.ufc.dto.Shard;
+import cloud.eppo.ufc.dto.Split;
+import cloud.eppo.ufc.dto.TargetingCondition;
+import cloud.eppo.ufc.dto.TargetingRule;
+import cloud.eppo.ufc.dto.Variation;
+import cloud.eppo.ufc.dto.VariationType;
+
+/**
+ * Hand-rolled serializer so that we don't rely on annotations and method names, which can be
+ * unreliable when ProGuard minification is in-use and not configured to protect
+ * JSON-serialization-related classes and annotations.
+ */
+public class FlagConfigResponseSerializer extends StdSerializer<FlagConfigResponse> {
+  private static final Logger log = LoggerFactory.getLogger(FlagConfigResponseSerializer.class);
+  private final EppoValueSerializer eppoValueSerializer = new EppoValueSerializer();
+
+  protected FlagConfigResponseSerializer(Class<FlagConfigResponse> vc) {
+    super(vc);
+  }
+
+  public FlagConfigResponseSerializer() {
+    this(null);
+  }
+
+  @Override
+  public void serialize(FlagConfigResponse src, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException, JacksonException {
+    jgen.writeStartObject();
+    final FlagConfigResponse.Format format = src.getFormat();
+    if (format != null) {
+      jgen.writeStringField("format", format.name());
+    }
+    final Map<String, FlagConfig> flags = src.getFlags();
+    if (flags != null) {
+      jgen.writeFieldName("flags");
+      jgen.writeStartObject();
+      for (Map.Entry<String, FlagConfig> entry : src.getFlags().entrySet()) {
+        jgen.writeFieldName(entry.getKey());
+        serializeFlag(entry.getValue(), jgen, provider);
+      }
+      jgen.writeEndObject();
+    }
+    final Map<String, BanditReference> banditReferences = src.getBanditReferences();
+    if (banditReferences != null) {
+      jgen.writeFieldName("banditReferences");
+      jgen.writeStartObject();
+      for (Map.Entry<String, BanditReference> entry : banditReferences.entrySet()) {
+        jgen.writeFieldName(entry.getKey());
+        serializeBanditReference(entry.getValue(), jgen);
+      }
+      jgen.writeEndObject();
+    }
+    jgen.writeEndObject();
+  }
+
+  private void serializeFlag(FlagConfig flagConfig, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeStartObject();
+    jgen.writeStringField("key", flagConfig.getKey());
+    jgen.writeBooleanField("enabled", flagConfig.isEnabled());
+    jgen.writeNumberField("totalShards", flagConfig.getTotalShards());
+    final VariationType variationType = flagConfig.getVariationType();
+    if (variationType != null) {
+      jgen.writeStringField("variationType", variationType.value);
+    }
+    final Map<String, Variation> variations = flagConfig.getVariations();
+    if (variations != null) {
+      jgen.writeFieldName("variations");
+      jgen.writeStartObject();
+      for (Map.Entry<String, Variation> entry : variations.entrySet()) {
+        jgen.writeFieldName(entry.getKey());
+        serializeVariation(entry.getValue(), jgen);
+      }
+      jgen.writeEndObject();
+    }
+    final List<Allocation> allocations = flagConfig.getAllocations();
+    if (allocations != null) {
+      jgen.writeFieldName("allocations");
+      jgen.writeStartArray();
+      for (Allocation allocation : allocations) {
+        serializeAllocation(allocation, jgen, provider);
+      }
+      jgen.writeEndArray();
+    }
+    jgen.writeEndObject();
+  }
+
+  private void serializeVariation(Variation variation, JsonGenerator jgen)
+      throws IOException {
+    jgen.writeStartObject();
+    jgen.writeStringField("key", variation.getKey());
+    jgen.writeObjectField("value", variation.getValue());
+    jgen.writeEndObject();
+  }
+
+  private void serializeAllocation(Allocation allocation, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeStartObject();
+    jgen.writeStringField("key", allocation.getKey());
+    final Set<TargetingRule> rules = allocation.getRules();
+    if (rules != null) {
+      jgen.writeFieldName("rules");
+      jgen.writeStartArray();
+      for (TargetingRule rule : rules) {
+        serializeTargetingRule(rule, jgen, provider);
+      }
+      jgen.writeEndArray();
+    }
+    final Date startAt = allocation.getStartAt();
+    if (startAt != null) {
+      jgen.writeStringField("startAt", getISODate(startAt));
+    }
+    final Date endAt = allocation.getEndAt();
+    if (endAt != null) {
+      jgen.writeStringField("endAt", getISODate(endAt));
+    }
+    final List<Split> splits = allocation.getSplits();
+    if (splits != null) {
+      jgen.writeFieldName("splits");
+      jgen.writeStartArray();
+      for (Split split : splits) {
+        serializeSplit(split, jgen);
+      }
+      jgen.writeEndArray();
+    }
+    jgen.writeBooleanField("doLog", allocation.doLog());
+
+    jgen.writeEndObject();
+  }
+
+  private void serializeTargetingRule(TargetingRule rule, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException {
+    jgen.writeStartObject();
+    final Set<TargetingCondition> conditions = rule.getConditions();
+    if (conditions != null) {
+      jgen.writeFieldName("conditions");
+      jgen.writeStartArray();
+      for (TargetingCondition condition : conditions) {
+        jgen.writeStartObject();
+        jgen.writeStringField("attribute", condition.getAttribute());
+        final OperatorType operator = condition.getOperator();
+        if (operator != null) {
+          jgen.writeStringField("operator", operator.value);
+        }
+        final EppoValue value = condition.getValue();
+        if (value != null) {
+          jgen.writeFieldName("value");
+          eppoValueSerializer.serialize(value, jgen, provider);
+        }
+
+        jgen.writeEndObject();
+      }
+      jgen.writeEndArray();
+    }
+    jgen.writeEndObject();
+  }
+
+  private void serializeSplit(Split split, JsonGenerator jgen)
+      throws IOException {
+    jgen.writeStartObject();
+    jgen.writeStringField("variationKey", split.getVariationKey());
+    final Set<Shard> shards = split.getShards();
+    if (shards != null) {
+      jgen.writeFieldName("shards");
+      jgen.writeStartArray();
+      for (Shard shard : shards) {
+        serializeShard(shard, jgen);
+      }
+      jgen.writeEndArray();
+    }
+    Map<String, String> extraLogging = split.getExtraLogging();
+    if (extraLogging != null) {
+      jgen.writeFieldName("extraLogging");
+      jgen.writeStartObject();
+      for (Map.Entry<String, String> extraLog : extraLogging.entrySet()) {
+        jgen.writeStringField(extraLog.getKey(), extraLog.getValue());
+      }
+      jgen.writeEndObject();
+    }
+    jgen.writeEndObject();
+  }
+
+  private void serializeShard(Shard shard, JsonGenerator jgen)
+      throws IOException {
+    jgen.writeStartObject();
+    jgen.writeStringField("salt", shard.getSalt());
+    final Set<ShardRange> ranges = shard.getRanges();
+    if (ranges != null) {
+      jgen.writeFieldName("ranges");
+      jgen.writeStartArray();
+      for (ShardRange range : ranges) {
+        jgen.writeStartObject();
+        jgen.writeNumberField("start", range.getStart());
+        jgen.writeNumberField("end", range.getEnd());
+        jgen.writeEndObject();
+      }
+      jgen.writeEndArray();
+    }
+    jgen.writeEndObject();
+  }
+
+  private void serializeBanditReference(BanditReference banditReference, JsonGenerator jgen)
+      throws IOException {
+    jgen.writeStartObject();
+    jgen.writeStringField("modelVersion", banditReference.getModelVersion());
+    List<BanditFlagVariation> flagVariations = banditReference.getFlagVariations();
+    if (flagVariations != null) {
+      jgen.writeFieldName("flagVariations");
+      jgen.writeStartArray();
+      for (BanditFlagVariation flagVariation : flagVariations) {
+        jgen.writeStartObject();
+        jgen.writeStringField("key", flagVariation.getBanditKey());
+        jgen.writeStringField("flagKey", flagVariation.getFlagKey());
+        jgen.writeStringField("allocationKey", flagVariation.getAllocationKey());
+        jgen.writeStringField("variationKey", flagVariation.getVariationKey());
+        jgen.writeStringField("variationValue", flagVariation.getVariationValue());
+        jgen.writeEndObject();
+      }
+      jgen.writeEndArray();
+    }
+    jgen.writeEndObject();
+  }
+}


### PR DESCRIPTION
Previous implementation didn't have a serializer

`EppoValueSerializer` should only write one value: Previous implemenation could write multiple values (would always write a `null`) for anything that isn't an `ARRAY_OF_STRING` type

_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context

We want to preserve old flag values on our clients, so we need to be able to serialize a `FlagConfigResponse` that we generate on the client by combining the newly received `FlagConfigResposne` and the existing `FlagConfigResponse`

## Description

Wrote a `FlagConfigResponseSerializer` that mirrors the implementation in `FlagConfigResponseDeserializer`

## How has this been documented?

Added equivalent javadoc to what existed in `FlagConfigResponseDeserializer`

## How has this been tested?

Added equivalent testing to what existed in `FlagConfigResponseSerializer`. Added another case to test serializing / deserializing `BanditReference`
