### PR TITLE
fix: hardcode repo only for workflow_call runs of the workflow

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -27,6 +27,7 @@ env:
   CI: true
   SDK_BRANCH: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
   TEST_DATA_BRANCH: ${{ inputs.test_data_branch || 'main' }}
+  SDK_REPO: ${{ (github.event_name == 'workflow_call' && 'Eppo-exp/sdk-common-jdk') || github.repository }}
 
 jobs:
   lint-test-sdk:
@@ -37,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: Eppo-exp/sdk-common-jdk
+          repository: ${{ env.SDK_REPO }}
           ref: ${{ env.SDK_BRANCH }}
           fetch-depth: 0
 


### PR DESCRIPTION
This allows the testing workflow to run on forked branches in friends' repositories
context: [#119](https://github.com/Eppo-exp/sdk-common-jdk/actions/runs/15122712648)
