### PR TITLE
Add API to show all flag keys

### DIFF
--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -170,7 +170,7 @@ public class Configuration {
     return flags == null || flags.isEmpty();
   }
 
-  public Set<String> getAllFlagKeys() {
+  public Set<String> getFlagKeys() {
     if (flags == null) {
       return Collections.emptySet();
     } else {

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -170,6 +170,14 @@ public class Configuration {
     return flags == null || flags.isEmpty();
   }
 
+  public Set<String> getAllFlagKeys() {
+    if (flags == null) {
+      return Collections.emptySet();
+    } else {
+      return flags.keySet();
+    }
+  }
+
   public static Builder builder(byte[] flagJson) {
     return new Builder(flagJson);
   }

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -171,11 +171,7 @@ public class Configuration {
   }
 
   public Set<String> getFlagKeys() {
-    if (flags == null) {
-      return Collections.emptySet();
-    } else {
-      return flags.keySet();
-    }
+    return flags == null ? Collections.emptySet() : flags.keySet();
   }
 
   public static Builder builder(byte[] flagJson) {

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -742,6 +742,7 @@ public class BaseEppoClientTest {
     // Verify we get an empty configuration
     assertNotNull(config);
     assertTrue(config.isEmpty());
+    assertEquals(Collections.emptySet(), config.getAllFlagKeys());
 
     eppoClient.loadConfiguration();
 
@@ -751,6 +752,7 @@ public class BaseEppoClientTest {
     // Verify we get an empty configuration
     assertNotNull(nextConfig);
     assertFalse(nextConfig.isEmpty());
+    assertFalse(nextConfig.getAllFlagKeys().isEmpty());
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/src/test/java/cloud/eppo/BaseEppoClientTest.java
+++ b/src/test/java/cloud/eppo/BaseEppoClientTest.java
@@ -742,7 +742,7 @@ public class BaseEppoClientTest {
     // Verify we get an empty configuration
     assertNotNull(config);
     assertTrue(config.isEmpty());
-    assertEquals(Collections.emptySet(), config.getAllFlagKeys());
+    assertEquals(Collections.emptySet(), config.getFlagKeys());
 
     eppoClient.loadConfiguration();
 
@@ -752,7 +752,7 @@ public class BaseEppoClientTest {
     // Verify we get an empty configuration
     assertNotNull(nextConfig);
     assertFalse(nextConfig.isEmpty());
-    assertFalse(nextConfig.getAllFlagKeys().isEmpty());
+    assertFalse(nextConfig.getFlagKeys().isEmpty());
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -41,13 +41,13 @@ public class ConfigurationRequestorTest {
 
     // verify config is empty to start
     assertTrue(configStore.getConfiguration().isEmpty());
-    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getFlagKeys());
     Mockito.verify(configStore, Mockito.times(0)).saveConfiguration(any());
 
     futureConfig.complete(Configuration.builder(flagConfig, false).build());
 
     assertFalse(configStore.getConfiguration().isEmpty());
-    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
+    assertFalse(configStore.getConfiguration().getFlagKeys().isEmpty());
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
     assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
   }
@@ -72,7 +72,7 @@ public class ConfigurationRequestorTest {
     requestor.setInitialConfiguration(initialConfigFuture);
 
     assertTrue(configStore.getConfiguration().isEmpty());
-    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getFlagKeys());
     Mockito.verify(configStore, Mockito.times(0)).saveConfiguration(any());
 
     // The initial config contains only one flag keyed `numeric_flag`. The fetch response has only
@@ -86,7 +86,7 @@ public class ConfigurationRequestorTest {
     initialConfigFuture.complete(new Configuration.Builder(flagConfig, false).build());
 
     assertFalse(configStore.getConfiguration().isEmpty());
-    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
+    assertFalse(configStore.getConfiguration().getFlagKeys().isEmpty());
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
 
     // `numeric_flag` is only in the cache which should have been ignored.
@@ -114,7 +114,7 @@ public class ConfigurationRequestorTest {
     requestor.setInitialConfiguration(initialConfigFuture);
 
     assertTrue(configStore.getConfiguration().isEmpty());
-    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getFlagKeys());
     Mockito.verify(configStore, Mockito.times(0)).saveConfiguration(any());
 
     requestor.fetchAndSaveFromRemoteAsync();
@@ -126,7 +126,7 @@ public class ConfigurationRequestorTest {
     configFetchFuture.completeExceptionally(new Exception("Intentional exception"));
 
     assertFalse(configStore.getConfiguration().isEmpty());
-    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
+    assertFalse(configStore.getConfiguration().getFlagKeys().isEmpty());
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
 
     // `numeric_flag` is only in the cache which should be available
@@ -155,7 +155,7 @@ public class ConfigurationRequestorTest {
 
     // default configuration is empty config.
     assertTrue(configStore.getConfiguration().isEmpty());
-    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getFlagKeys());
 
     // Fetch from remote with an error
     requestor.fetchAndSaveFromRemoteAsync();
@@ -167,7 +167,7 @@ public class ConfigurationRequestorTest {
     // Verify that a configuration was saved by the requestor
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
     assertFalse(configStore.getConfiguration().isEmpty());
-    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
+    assertFalse(configStore.getConfiguration().getFlagKeys().isEmpty());
 
     // `numeric_flag` is only in the cache which should be available
     assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));

--- a/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
+++ b/src/test/java/cloud/eppo/ConfigurationRequestorTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,11 +41,13 @@ public class ConfigurationRequestorTest {
 
     // verify config is empty to start
     assertTrue(configStore.getConfiguration().isEmpty());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
     Mockito.verify(configStore, Mockito.times(0)).saveConfiguration(any());
 
     futureConfig.complete(Configuration.builder(flagConfig, false).build());
 
     assertFalse(configStore.getConfiguration().isEmpty());
+    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
     assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));
   }
@@ -69,6 +72,7 @@ public class ConfigurationRequestorTest {
     requestor.setInitialConfiguration(initialConfigFuture);
 
     assertTrue(configStore.getConfiguration().isEmpty());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
     Mockito.verify(configStore, Mockito.times(0)).saveConfiguration(any());
 
     // The initial config contains only one flag keyed `numeric_flag`. The fetch response has only
@@ -82,6 +86,7 @@ public class ConfigurationRequestorTest {
     initialConfigFuture.complete(new Configuration.Builder(flagConfig, false).build());
 
     assertFalse(configStore.getConfiguration().isEmpty());
+    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
 
     // `numeric_flag` is only in the cache which should have been ignored.
@@ -109,6 +114,7 @@ public class ConfigurationRequestorTest {
     requestor.setInitialConfiguration(initialConfigFuture);
 
     assertTrue(configStore.getConfiguration().isEmpty());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
     Mockito.verify(configStore, Mockito.times(0)).saveConfiguration(any());
 
     requestor.fetchAndSaveFromRemoteAsync();
@@ -120,6 +126,7 @@ public class ConfigurationRequestorTest {
     configFetchFuture.completeExceptionally(new Exception("Intentional exception"));
 
     assertFalse(configStore.getConfiguration().isEmpty());
+    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
 
     // `numeric_flag` is only in the cache which should be available
@@ -148,6 +155,7 @@ public class ConfigurationRequestorTest {
 
     // default configuration is empty config.
     assertTrue(configStore.getConfiguration().isEmpty());
+    assertEquals(Collections.emptySet(), configStore.getConfiguration().getAllFlagKeys());
 
     // Fetch from remote with an error
     requestor.fetchAndSaveFromRemoteAsync();
@@ -159,6 +167,7 @@ public class ConfigurationRequestorTest {
     // Verify that a configuration was saved by the requestor
     Mockito.verify(configStore, Mockito.times(1)).saveConfiguration(any());
     assertFalse(configStore.getConfiguration().isEmpty());
+    assertFalse(configStore.getConfiguration().getAllFlagKeys().isEmpty());
 
     // `numeric_flag` is only in the cache which should be available
     assertNotNull(configStore.getConfiguration().getFlag("numeric_flag"));


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context

This makes comparing flags between different `Configuration` versions easier. Otherwise, we must deserialize another `FlagConfigResponse` instance from `flagConfigJson`, which is slower.

## Description

Exposes the `flags.keySet()` to as public API on `Configuration`

## How has this been documented?

No documentation because `Configuration.isEmpty()` has no documentation.

## How has this been tested?

Added tests in the same places where `Configuration.isEmpty()` is tested.