### PR TITLE
Make EppoValue.type publicly accessible

### DIFF
--- a/src/main/java/cloud/eppo/api/EppoValue.java
+++ b/src/main/java/cloud/eppo/api/EppoValue.java
@@ -92,6 +92,10 @@ public class EppoValue {
     return type == EppoValueType.ARRAY_OF_STRING;
   }
 
+  public EppoValueType getType() {
+    return type;
+  }
+
   @Override
   public String toString() {
     switch (this.type) {


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context

Allows one to switch over all possible `EppoValueType` cases with a compile-time failure if `EppoValueType` changes.

## Description

Simple `EppoValue.getType()` getter.

## How has this been documented?

No documentation, consistent with other getters

## How has this been tested?

No tests. Consistent with other getters
