### PR TITLE
Added equals/hashCode/toString methods to all bean objects

### DIFF
--- a/src/main/java/cloud/eppo/BanditEvaluationResult.java
+++ b/src/main/java/cloud/eppo/BanditEvaluationResult.java
@@ -1,5 +1,7 @@
 package cloud.eppo;
 
+import java.util.Objects;
+
 import cloud.eppo.api.DiscriminableAttributes;
 
 public class BanditEvaluationResult {
@@ -33,6 +35,40 @@ public class BanditEvaluationResult {
     this.actionWeight = actionWeight;
     this.gamma = gamma;
     this.optimalityGap = optimalityGap;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditEvaluationResult{" +
+      "flagKey='" + flagKey + '\'' +
+      ", subjectKey='" + subjectKey + '\'' +
+      ", subjectAttributes=" + subjectAttributes +
+      ", actionKey='" + actionKey + '\'' +
+      ", actionAttributes=" + actionAttributes +
+      ", actionScore=" + actionScore +
+      ", actionWeight=" + actionWeight +
+      ", gamma=" + gamma +
+      ", optimalityGap=" + optimalityGap +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditEvaluationResult that = (BanditEvaluationResult) o;
+    return Double.compare(actionScore, that.actionScore) == 0
+            && Double.compare(actionWeight, that.actionWeight) == 0
+            && Double.compare(gamma, that.gamma) == 0
+            && Double.compare(optimalityGap, that.optimalityGap) == 0
+            && Objects.equals(flagKey, that.flagKey)
+            && Objects.equals(subjectKey, that.subjectKey)
+            && Objects.equals(subjectAttributes, that.subjectAttributes)
+            && Objects.equals(actionKey, that.actionKey) && Objects.equals(actionAttributes, that.actionAttributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(flagKey, subjectKey, subjectAttributes, actionKey, actionAttributes, actionScore, actionWeight, gamma, optimalityGap);
   }
 
   public String getFlagKey() {

--- a/src/main/java/cloud/eppo/FlagEvaluationResult.java
+++ b/src/main/java/cloud/eppo/FlagEvaluationResult.java
@@ -3,6 +3,7 @@ package cloud.eppo;
 import cloud.eppo.api.Attributes;
 import cloud.eppo.ufc.dto.Variation;
 import java.util.Map;
+import java.util.Objects;
 
 public class FlagEvaluationResult {
 
@@ -29,6 +30,37 @@ public class FlagEvaluationResult {
     this.variation = variation;
     this.extraLogging = extraLogging;
     this.doLog = doLog;
+  }
+
+  @Override
+  public String toString() {
+    return "FlagEvaluationResult{" +
+      "flagKey='" + flagKey + '\'' +
+      ", subjectKey='" + subjectKey + '\'' +
+      ", subjectAttributes=" + subjectAttributes +
+      ", allocationKey='" + allocationKey + '\'' +
+      ", variation=" + variation +
+      ", extraLogging=" + extraLogging +
+      ", doLog=" + doLog +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    FlagEvaluationResult that = (FlagEvaluationResult) o;
+    return doLog == that.doLog
+            && Objects.equals(flagKey, that.flagKey)
+            && Objects.equals(subjectKey, that.subjectKey)
+            && Objects.equals(subjectAttributes, that.subjectAttributes)
+            && Objects.equals(allocationKey, that.allocationKey)
+            && Objects.equals(variation, that.variation)
+            && Objects.equals(extraLogging, that.extraLogging);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(flagKey, subjectKey, subjectAttributes, allocationKey, variation, extraLogging, doLog);
   }
 
   public String getFlagKey() {

--- a/src/main/java/cloud/eppo/SDKKey.java
+++ b/src/main/java/cloud/eppo/SDKKey.java
@@ -5,6 +5,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +24,27 @@ public class SDKKey {
   public SDKKey(String sdkToken) {
     this.sdkTokenString = sdkToken;
     this.decodedParams = decodeToken(sdkToken);
+  }
+
+  @Override
+  public String toString() {
+    return "SDKKey{" +
+      "sdkTokenString='" + sdkTokenString + '\'' +
+      ", decodedParams=" + decodedParams +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    SDKKey sdkKey = (SDKKey) o;
+    return Objects.equals(sdkTokenString, sdkKey.sdkTokenString) &&
+            Objects.equals(decodedParams, sdkKey.decodedParams);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sdkTokenString, decodedParams);
   }
 
   private Map<String, String> decodeToken(String token) {

--- a/src/main/java/cloud/eppo/api/BanditResult.java
+++ b/src/main/java/cloud/eppo/api/BanditResult.java
@@ -1,5 +1,7 @@
 package cloud.eppo.api;
 
+import java.util.Objects;
+
 public class BanditResult {
   private final String variation;
   private final String action;
@@ -7,6 +9,27 @@ public class BanditResult {
   public BanditResult(String variation, String action) {
     this.variation = variation;
     this.action = action;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditResult{" +
+      "variation='" + variation + '\'' +
+      ", action='" + action + '\'' +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditResult that = (BanditResult) o;
+    return Objects.equals(variation, that.variation)
+      && Objects.equals(action, that.action);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(variation, action);
   }
 
   public String getVariation() {

--- a/src/main/java/cloud/eppo/api/Configuration.java
+++ b/src/main/java/cloud/eppo/api/Configuration.java
@@ -8,8 +8,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.*;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.Nullable;
@@ -105,6 +107,35 @@ public class Configuration {
         false,
         emptyFlagsBytes,
         null);
+  }
+
+  @Override
+  public String toString() {
+    return "Configuration{" +
+      "banditReferences=" + banditReferences +
+      ", flags=" + flags +
+      ", bandits=" + bandits +
+      ", isConfigObfuscated=" + isConfigObfuscated +
+      ", flagConfigJson=" + Arrays.toString(flagConfigJson) +
+      ", banditParamsJson=" + Arrays.toString(banditParamsJson) +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Configuration that = (Configuration) o;
+    return isConfigObfuscated == that.isConfigObfuscated
+            && Objects.equals(banditReferences, that.banditReferences)
+            && Objects.equals(flags, that.flags)
+            && Objects.equals(bandits, that.bandits)
+            && Objects.deepEquals(flagConfigJson, that.flagConfigJson)
+            && Objects.deepEquals(banditParamsJson, that.banditParamsJson);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(banditReferences, flags, bandits, isConfigObfuscated, Arrays.hashCode(flagConfigJson), Arrays.hashCode(banditParamsJson));
   }
 
   public FlagConfig getFlag(String flagKey) {

--- a/src/main/java/cloud/eppo/cache/AssignmentCacheEntry.java
+++ b/src/main/java/cloud/eppo/cache/AssignmentCacheEntry.java
@@ -27,6 +27,27 @@ public class AssignmentCacheEntry {
         new BanditCacheValue(assignment.getBandit(), assignment.getAction()));
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    AssignmentCacheEntry that = (AssignmentCacheEntry) o;
+    return Objects.equals(key, that.key)
+      && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value);
+  }
+
+  @Override
+  public String toString() {
+    return "AssignmentCacheEntry{" +
+      "key=" + key +
+      ", value=" + value +
+      '}';
+  }
+
   @NotNull public AssignmentCacheKey getKey() {
     return key;
   }
@@ -43,17 +64,4 @@ public class AssignmentCacheEntry {
     return value;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    AssignmentCacheEntry that = (AssignmentCacheEntry) o;
-    return Objects.equals(key, that.key)
-        && Objects.equals(value.getValueIdentifier(), that.value.getValueIdentifier());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(key, value);
-  }
 }

--- a/src/main/java/cloud/eppo/cache/AssignmentCacheKey.java
+++ b/src/main/java/cloud/eppo/cache/AssignmentCacheKey.java
@@ -17,6 +17,24 @@ public class AssignmentCacheKey {
     this.flagKey = flagKey;
   }
 
+  @Override
+  public String toString() {
+    return subjectKey + ";" + flagKey;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    AssignmentCacheKey that = (AssignmentCacheKey) o;
+    return Objects.equals(subjectKey, that.subjectKey)
+            && Objects.equals(flagKey, that.flagKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(subjectKey, flagKey);
+  }
+
   public String getSubjectKey() {
     return subjectKey;
   }
@@ -25,21 +43,4 @@ public class AssignmentCacheKey {
     return flagKey;
   }
 
-  @Override
-  public String toString() {
-    return subjectKey + ";" + flagKey;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    AssignmentCacheKey that = (AssignmentCacheKey) o;
-    return Objects.equals(toString(), that.toString());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(subjectKey, flagKey);
-  }
 }

--- a/src/main/java/cloud/eppo/model/ShardRange.java
+++ b/src/main/java/cloud/eppo/model/ShardRange.java
@@ -3,6 +3,8 @@ package cloud.eppo.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 /** Shard Range Class */
 public class ShardRange {
   private final int start;
@@ -12,6 +14,19 @@ public class ShardRange {
   public ShardRange(@JsonProperty("start") int start, @JsonProperty("end") int end) {
     this.start = start;
     this.end = end;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    ShardRange that = (ShardRange) o;
+    return start == that.start &&
+            end == that.end;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, end);
   }
 
   @Override

--- a/src/main/java/cloud/eppo/ufc/dto/Allocation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Allocation.java
@@ -2,6 +2,7 @@ package cloud.eppo.ufc.dto;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class Allocation {
@@ -25,6 +26,35 @@ public class Allocation {
     this.endAt = endAt;
     this.splits = splits;
     this.doLog = doLog;
+  }
+
+  @Override
+  public String toString() {
+    return "Allocation{" +
+      "key='" + key + '\'' +
+      ", rules=" + rules +
+      ", startAt=" + startAt +
+      ", endAt=" + endAt +
+      ", splits=" + splits +
+      ", doLog=" + doLog +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Allocation that = (Allocation) o;
+    return doLog == that.doLog
+            && Objects.equals(key, that.key)
+            && Objects.equals(rules, that.rules)
+            && Objects.equals(startAt, that.startAt)
+            && Objects.equals(endAt, that.endAt)
+            && Objects.equals(splits, that.splits);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, rules, startAt, endAt, splits, doLog);
   }
 
   public String getKey() {

--- a/src/main/java/cloud/eppo/ufc/dto/BanditCategoricalAttributeCoefficients.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditCategoricalAttributeCoefficients.java
@@ -2,6 +2,8 @@ package cloud.eppo.ufc.dto;
 
 import cloud.eppo.api.EppoValue;
 import java.util.Map;
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +19,30 @@ public class BanditCategoricalAttributeCoefficients implements BanditAttributeCo
     this.attributeKey = attributeKey;
     this.missingValueCoefficient = missingValueCoefficient;
     this.valueCoefficients = valueCoefficients;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditCategoricalAttributeCoefficients{" +
+      "attributeKey='" + attributeKey + '\'' +
+      ", missingValueCoefficient=" + missingValueCoefficient +
+      ", valueCoefficients=" + valueCoefficients +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditCategoricalAttributeCoefficients that = (BanditCategoricalAttributeCoefficients) o;
+    return Objects.equals(logger, that.logger)
+            && Objects.equals(attributeKey, that.attributeKey)
+            && Objects.equals(missingValueCoefficient, that.missingValueCoefficient)
+            && Objects.equals(valueCoefficients, that.valueCoefficients);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(logger, attributeKey, missingValueCoefficient, valueCoefficients);
   }
 
   @Override

--- a/src/main/java/cloud/eppo/ufc/dto/BanditCoefficients.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditCoefficients.java
@@ -1,6 +1,7 @@
 package cloud.eppo.ufc.dto;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class BanditCoefficients {
   private final String actionKey;
@@ -23,6 +24,35 @@ public class BanditCoefficients {
     this.subjectCategoricalCoefficients = subjectCategoricalAttributeCoefficients;
     this.actionNumericCoefficients = actionNumericAttributeCoefficients;
     this.actionCategoricalCoefficients = actionCategoricalAttributeCoefficients;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditCoefficients{" +
+      "actionKey='" + actionKey + '\'' +
+      ", intercept=" + intercept +
+      ", subjectNumericCoefficients=" + subjectNumericCoefficients +
+      ", subjectCategoricalCoefficients=" + subjectCategoricalCoefficients +
+      ", actionNumericCoefficients=" + actionNumericCoefficients +
+      ", actionCategoricalCoefficients=" + actionCategoricalCoefficients +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditCoefficients that = (BanditCoefficients) o;
+    return Objects.equals(actionKey, that.actionKey)
+            && Objects.equals(intercept, that.intercept)
+            && Objects.equals(subjectNumericCoefficients, that.subjectNumericCoefficients)
+            && Objects.equals(subjectCategoricalCoefficients, that.subjectCategoricalCoefficients)
+            && Objects.equals(actionNumericCoefficients, that.actionNumericCoefficients)
+            && Objects.equals(actionCategoricalCoefficients, that.actionCategoricalCoefficients);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(actionKey, intercept, subjectNumericCoefficients, subjectCategoricalCoefficients, actionNumericCoefficients, actionCategoricalCoefficients);
   }
 
   public String getActionKey() {

--- a/src/main/java/cloud/eppo/ufc/dto/BanditFlagVariation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditFlagVariation.java
@@ -1,5 +1,7 @@
 package cloud.eppo.ufc.dto;
 
+import java.util.Objects;
+
 public class BanditFlagVariation {
   private final String banditKey;
   private final String flagKey;
@@ -18,6 +20,33 @@ public class BanditFlagVariation {
     this.allocationKey = allocationKey;
     this.variationKey = variationKey;
     this.variationValue = variationValue;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditFlagVariation{" +
+      "banditKey='" + banditKey + '\'' +
+      ", flagKey='" + flagKey + '\'' +
+      ", allocationKey='" + allocationKey + '\'' +
+      ", variationKey='" + variationKey + '\'' +
+      ", variationValue='" + variationValue + '\'' +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditFlagVariation that = (BanditFlagVariation) o;
+    return Objects.equals(banditKey, that.banditKey)
+            && Objects.equals(flagKey, that.flagKey)
+            && Objects.equals(allocationKey, that.allocationKey)
+            && Objects.equals(variationKey, that.variationKey)
+            && Objects.equals(variationValue, that.variationValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(banditKey, flagKey, allocationKey, variationKey, variationValue);
   }
 
   public String getBanditKey() {

--- a/src/main/java/cloud/eppo/ufc/dto/BanditModelData.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditModelData.java
@@ -1,6 +1,7 @@
 package cloud.eppo.ufc.dto;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class BanditModelData {
   private final Double gamma;
@@ -17,6 +18,31 @@ public class BanditModelData {
     this.defaultActionScore = defaultActionScore;
     this.actionProbabilityFloor = actionProbabilityFloor;
     this.coefficients = coefficients;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditModelData{" +
+      "gamma=" + gamma +
+      ", defaultActionScore=" + defaultActionScore +
+      ", actionProbabilityFloor=" + actionProbabilityFloor +
+      ", coefficients=" + coefficients +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditModelData that = (BanditModelData) o;
+    return Objects.equals(gamma, that.gamma)
+            && Objects.equals(defaultActionScore, that.defaultActionScore)
+            && Objects.equals(actionProbabilityFloor, that.actionProbabilityFloor)
+            && Objects.equals(coefficients, that.coefficients);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(gamma, defaultActionScore, actionProbabilityFloor, coefficients);
   }
 
   public Double getGamma() {

--- a/src/main/java/cloud/eppo/ufc/dto/BanditNumericAttributeCoefficients.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditNumericAttributeCoefficients.java
@@ -4,6 +4,8 @@ import cloud.eppo.api.EppoValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 public class BanditNumericAttributeCoefficients implements BanditAttributeCoefficients {
   private final Logger logger = LoggerFactory.getLogger(BanditNumericAttributeCoefficients.class);
   private final String attributeKey;
@@ -15,6 +17,30 @@ public class BanditNumericAttributeCoefficients implements BanditAttributeCoeffi
     this.attributeKey = attributeKey;
     this.coefficient = coefficient;
     this.missingValueCoefficient = missingValueCoefficient;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditNumericAttributeCoefficients{" +
+      "attributeKey='" + attributeKey + '\'' +
+      ", coefficient=" + coefficient +
+      ", missingValueCoefficient=" + missingValueCoefficient +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditNumericAttributeCoefficients that = (BanditNumericAttributeCoefficients) o;
+    return Objects.equals(logger, that.logger)
+            && Objects.equals(attributeKey, that.attributeKey)
+            && Objects.equals(coefficient, that.coefficient)
+            && Objects.equals(missingValueCoefficient, that.missingValueCoefficient);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(logger, attributeKey, coefficient, missingValueCoefficient);
   }
 
   @Override

--- a/src/main/java/cloud/eppo/ufc/dto/BanditParameters.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditParameters.java
@@ -1,6 +1,7 @@
 package cloud.eppo.ufc.dto;
 
 import java.util.Date;
+import java.util.Objects;
 
 public class BanditParameters {
   private final String banditKey;
@@ -20,6 +21,33 @@ public class BanditParameters {
     this.modelName = modelName;
     this.modelVersion = modelVersion;
     this.modelData = modelData;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditParameters{" +
+      "banditKey='" + banditKey + '\'' +
+      ", updatedAt=" + updatedAt +
+      ", modelName='" + modelName + '\'' +
+      ", modelVersion='" + modelVersion + '\'' +
+      ", modelData=" + modelData +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditParameters that = (BanditParameters) o;
+    return Objects.equals(banditKey, that.banditKey)
+            && Objects.equals(updatedAt, that.updatedAt)
+            && Objects.equals(modelName, that.modelName)
+            && Objects.equals(modelVersion, that.modelVersion)
+            && Objects.equals(modelData, that.modelData);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(banditKey, updatedAt, modelName, modelVersion, modelData);
   }
 
   public String getBanditKey() {

--- a/src/main/java/cloud/eppo/ufc/dto/BanditParametersResponse.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditParametersResponse.java
@@ -2,6 +2,7 @@ package cloud.eppo.ufc.dto;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class BanditParametersResponse {
 
@@ -13,6 +14,25 @@ public class BanditParametersResponse {
 
   public BanditParametersResponse(Map<String, BanditParameters> bandits) {
     this.bandits = bandits;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditParametersResponse{" +
+      "bandits=" + bandits +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditParametersResponse that = (BanditParametersResponse) o;
+    return Objects.equals(bandits, that.bandits);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(bandits);
   }
 
   public Map<String, BanditParameters> getBandits() {

--- a/src/main/java/cloud/eppo/ufc/dto/BanditReference.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditReference.java
@@ -1,6 +1,7 @@
 package cloud.eppo.ufc.dto;
 
 import java.util.List;
+import java.util.Objects;
 
 public class BanditReference {
   private final String modelVersion;
@@ -9,6 +10,27 @@ public class BanditReference {
   public BanditReference(String modelVersion, List<BanditFlagVariation> flagVariations) {
     this.modelVersion = modelVersion;
     this.flagVariations = flagVariations;
+  }
+
+  @Override
+  public String toString() {
+    return "BanditReference{" +
+      "modelVersion='" + modelVersion + '\'' +
+      ", flagVariations=" + flagVariations +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    BanditReference that = (BanditReference) o;
+    return Objects.equals(modelVersion, that.modelVersion)
+            && Objects.equals(flagVariations, that.flagVariations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(modelVersion, flagVariations);
   }
 
   public String getModelVersion() {

--- a/src/main/java/cloud/eppo/ufc/dto/FlagConfig.java
+++ b/src/main/java/cloud/eppo/ufc/dto/FlagConfig.java
@@ -2,6 +2,7 @@ package cloud.eppo.ufc.dto;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class FlagConfig {
   private final String key;
@@ -24,6 +25,35 @@ public class FlagConfig {
     this.variationType = variationType;
     this.variations = variations;
     this.allocations = allocations;
+  }
+
+  @Override
+  public String toString() {
+    return "FlagConfig{" +
+      "key='" + key + '\'' +
+      ", enabled=" + enabled +
+      ", totalShards=" + totalShards +
+      ", variationType=" + variationType +
+      ", variations=" + variations +
+      ", allocations=" + allocations +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    FlagConfig that = (FlagConfig) o;
+    return enabled == that.enabled
+            && totalShards == that.totalShards
+            && Objects.equals(key, that.key)
+            && variationType == that.variationType
+            && Objects.equals(variations, that.variations)
+            && Objects.equals(allocations, that.allocations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, enabled, totalShards, variationType, variations, allocations);
   }
 
   public String getKey() {

--- a/src/main/java/cloud/eppo/ufc/dto/FlagConfigResponse.java
+++ b/src/main/java/cloud/eppo/ufc/dto/FlagConfigResponse.java
@@ -1,6 +1,7 @@
 package cloud.eppo.ufc.dto;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class FlagConfigResponse {
@@ -24,6 +25,29 @@ public class FlagConfigResponse {
 
   public FlagConfigResponse() {
     this(new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), Format.SERVER);
+  }
+
+  @Override
+  public String toString() {
+    return "FlagConfigResponse{" +
+      "flags=" + flags +
+      ", banditReferences=" + banditReferences +
+      ", format=" + format +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    FlagConfigResponse that = (FlagConfigResponse) o;
+    return Objects.equals(flags, that.flags)
+            && Objects.equals(banditReferences, that.banditReferences)
+            && format == that.format;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(flags, banditReferences, format);
   }
 
   public Map<String, FlagConfig> getFlags() {

--- a/src/main/java/cloud/eppo/ufc/dto/Shard.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Shard.java
@@ -1,6 +1,8 @@
 package cloud.eppo.ufc.dto;
 
 import cloud.eppo.model.ShardRange;
+
+import java.util.Objects;
 import java.util.Set;
 
 public class Shard {
@@ -10,6 +12,27 @@ public class Shard {
   public Shard(String salt, Set<ShardRange> ranges) {
     this.salt = salt;
     this.ranges = ranges;
+  }
+
+  @Override
+  public String toString() {
+    return "Shard{" +
+      "salt='" + salt + '\'' +
+      ", ranges=" + ranges +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Shard shard = (Shard) o;
+    return Objects.equals(salt, shard.salt)
+            && Objects.equals(ranges, shard.ranges);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(salt, ranges);
   }
 
   public String getSalt() {

--- a/src/main/java/cloud/eppo/ufc/dto/Split.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Split.java
@@ -1,6 +1,7 @@
 package cloud.eppo.ufc.dto;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class Split {
@@ -12,6 +13,29 @@ public class Split {
     this.variationKey = variationKey;
     this.shards = shards;
     this.extraLogging = extraLogging;
+  }
+
+  @Override
+  public String toString() {
+    return "Split{" +
+      "variationKey='" + variationKey + '\'' +
+      ", shards=" + shards +
+      ", extraLogging=" + extraLogging +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Split split = (Split) o;
+    return Objects.equals(variationKey, split.variationKey)
+            && Objects.equals(shards, split.shards)
+            && Objects.equals(extraLogging, split.extraLogging);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(variationKey, shards, extraLogging);
   }
 
   public String getVariationKey() {

--- a/src/main/java/cloud/eppo/ufc/dto/TargetingCondition.java
+++ b/src/main/java/cloud/eppo/ufc/dto/TargetingCondition.java
@@ -1,5 +1,7 @@
 package cloud.eppo.ufc.dto;
 
+import java.util.Objects;
+
 import cloud.eppo.api.EppoValue;
 
 public class TargetingCondition {
@@ -11,6 +13,29 @@ public class TargetingCondition {
     this.operator = operator;
     this.attribute = attribute;
     this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return "TargetingCondition{" +
+      "operator=" + operator +
+      ", attribute='" + attribute + '\'' +
+      ", value=" + value +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    TargetingCondition that = (TargetingCondition) o;
+    return operator == that.operator
+            && Objects.equals(attribute, that.attribute)
+            && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(operator, attribute, value);
   }
 
   public OperatorType getOperator() {

--- a/src/main/java/cloud/eppo/ufc/dto/TargetingRule.java
+++ b/src/main/java/cloud/eppo/ufc/dto/TargetingRule.java
@@ -1,5 +1,6 @@
 package cloud.eppo.ufc.dto;
 
+import java.util.Objects;
 import java.util.Set;
 
 public class TargetingRule {
@@ -11,5 +12,24 @@ public class TargetingRule {
 
   public Set<TargetingCondition> getConditions() {
     return conditions;
+  }
+
+  @Override
+  public String toString() {
+    return "TargetingRule{" +
+      "conditions=" + conditions +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    TargetingRule that = (TargetingRule) o;
+    return Objects.equals(conditions, that.conditions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(conditions);
   }
 }

--- a/src/main/java/cloud/eppo/ufc/dto/Variation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Variation.java
@@ -1,5 +1,7 @@
 package cloud.eppo.ufc.dto;
 
+import java.util.Objects;
+
 import cloud.eppo.api.EppoValue;
 
 public class Variation {
@@ -9,6 +11,27 @@ public class Variation {
   public Variation(String key, EppoValue value) {
     this.key = key;
     this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return "Variation{" +
+      "key='" + key + '\'' +
+      ", value=" + value +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Variation variation = (Variation) o;
+    return Objects.equals(key, variation.key)
+            && Objects.equals(value, variation.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value);
   }
 
   public String getKey() {


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
This makes unit testing easier for consumers. It shouldn't change any behaviors.

## Description
I generated everything with Android Studio. The only places I saw equals/hashCode/toString already had them directly after constructors, and ordered them: toString
equals
hashCode

so I preserved that position and order (and moved AssignmentCacheEntry's existing equals/hashCode to make it match that order).

## How has this been documented?
No new documentation. This is just standard bean behavior

## How has this been tested?
Your existing unit tests should suffice
