### PR TITLE
Reverted equals behavior change from PR 127

### DIFF
--- a/src/main/java/cloud/eppo/cache/AssignmentCacheEntry.java
+++ b/src/main/java/cloud/eppo/cache/AssignmentCacheEntry.java
@@ -32,7 +32,7 @@ public class AssignmentCacheEntry {
     if (o == null || getClass() != o.getClass()) return false;
     AssignmentCacheEntry that = (AssignmentCacheEntry) o;
     return Objects.equals(key, that.key)
-      && Objects.equals(value, that.value);
+      && Objects.equals(value.getValueIdentifier(), that.value.getValueIdentifier());
   }
 
   @Override


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
See https://github.com/Eppo-exp/sdk-common-jdk/pull/127/files#r2141103699

## Description
Reverted to previous `AssignmentCacheEntry.equals()` implementation

## How has this been documented?
None, same as before.

## How has this been tested?
Unit tests?
