### PR TITLE
Ignore the local.properties gradle file Android Studio generates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 src/test/resources/shared
+
+### Gradle ###
 .gradle
 build/
+local.properties
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context

Stops people from accidentally including `local.properties` in their PR if they develop in Android Studio
Creates a separate section in `.gitignore` for gradle files