### PR TITLE
Add putIfAbsent to IAssignmentCache

### DIFF
--- a/src/main/java/cloud/eppo/BaseEppoClient.java
+++ b/src/main/java/cloud/eppo/BaseEppoClient.java
@@ -267,17 +267,11 @@ public class BaseEppoClient {
         boolean logAssignment = true;
         AssignmentCacheEntry cacheEntry = AssignmentCacheEntry.fromVariationAssignment(assignment);
         if (assignmentCache != null) {
-          if (assignmentCache.hasEntry(cacheEntry)) {
-            logAssignment = false;
-          }
+          logAssignment = assignmentCache.putIfAbsent(cacheEntry);
         }
 
         if (logAssignment) {
           assignmentLogger.logAssignment(assignment);
-
-          if (assignmentCache != null) {
-            assignmentCache.put(cacheEntry);
-          }
         }
 
       } catch (Exception e) {

--- a/src/main/java/cloud/eppo/api/IAssignmentCache.java
+++ b/src/main/java/cloud/eppo/api/IAssignmentCache.java
@@ -7,6 +7,9 @@ import cloud.eppo.cache.AssignmentCacheEntry;
  * determine both presence and uniqueness of the cached value.
  */
 public interface IAssignmentCache {
+  /**
+   * Puts the entry into the cache, overwriting an existing entry.
+   */
   void put(AssignmentCacheEntry entry);
 
   /**
@@ -15,4 +18,10 @@ public interface IAssignmentCache {
    * comparing the `getValueKeyString()` method results.
    */
   boolean hasEntry(AssignmentCacheEntry entry);
+
+  /**
+   * Puts the entry into the cache if none exists.
+   * @return true if no previous cache entry exists, false otherwise
+   */
+  boolean putIfAbsent(AssignmentCacheEntry entry);
 }


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  This resolves a concurrency issue that allowed multiple AssignmentLogger callbacks on high contention first-experiment-access.

## Description
[//]: # Adds `IAssignmentCache.putIfAbsent()` method, which fixes the concurrency problem.

## How has this been documented?
[//]: # Added javadoc.

## How has this been tested?
[//]: # Added a high-contention unit test that failed without the fix and passed with it.
