### PR TITLE
Added BaseEppoClient.getTypedAssignmentResult + nullability

### DIFF
--- a/src/main/java/cloud/eppo/FlagEvaluationAllocationKeyAndVariation.java
+++ b/src/main/java/cloud/eppo/FlagEvaluationAllocationKeyAndVariation.java
@@ -1,0 +1,54 @@
+package cloud.eppo;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+import cloud.eppo.ufc.dto.Variation;
+
+/**
+ * Holds an allocation key and a variation because these two values
+ * either both need to be null or both need to be not-null in a
+ * FlagEvaluationResult. This makes nullability easier to enforce.
+ */
+public class FlagEvaluationAllocationKeyAndVariation {
+  @NotNull
+  final String allocationKey;
+  @NotNull final Variation variation;
+
+  public FlagEvaluationAllocationKeyAndVariation(@NotNull String allocationKey, @NotNull Variation variation) {
+    this.allocationKey = allocationKey;
+    this.variation = variation;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    FlagEvaluationAllocationKeyAndVariation that = (FlagEvaluationAllocationKeyAndVariation) o;
+    return Objects.equals(allocationKey, that.allocationKey) && Objects.equals(variation, that.variation);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(allocationKey, variation);
+  }
+
+  @Override
+  public String toString() {
+    return "AllocationKeyAndVariation{" +
+      "allocationKey='" + allocationKey + '\'' +
+      ", variation=" + variation +
+      '}';
+  }
+
+  @NotNull
+  public String getAllocationKey() {
+    return allocationKey;
+  }
+
+  @NotNull
+  public Variation getVariation() {
+    return variation;
+  }
+}

--- a/src/main/java/cloud/eppo/FlagEvaluationResult.java
+++ b/src/main/java/cloud/eppo/FlagEvaluationResult.java
@@ -1,88 +1,115 @@
 package cloud.eppo;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import cloud.eppo.api.Attributes;
+import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.Variation;
 import java.util.Map;
 import java.util.Objects;
 
 public class FlagEvaluationResult {
-
-  private final String flagKey;
-  private final String subjectKey;
-  private final Attributes subjectAttributes;
-  private final String allocationKey;
-  private final Variation variation;
-  private final Map<String, String> extraLogging;
+  @NotNull private final FlagConfig flag;
+  @NotNull private final String flagKey;
+  @NotNull private final String subjectKey;
+  @NotNull private final Attributes subjectAttributes;
+  @Nullable private final FlagEvaluationAllocationKeyAndVariation allocationKeyAndVariation;
+  @NotNull private final Map<String, String> extraLogging;
   private final boolean doLog;
 
   public FlagEvaluationResult(
-      String flagKey,
-      String subjectKey,
-      Attributes subjectAttributes,
-      String allocationKey,
-      Variation variation,
-      Map<String, String> extraLogging,
+      @NotNull FlagConfig flag,
+      @NotNull String flagKey,
+      @NotNull String subjectKey,
+      @NotNull Attributes subjectAttributes,
+      @Nullable FlagEvaluationAllocationKeyAndVariation allocationKeyAndVariation,
+      @NotNull Map<String, String> extraLogging,
       boolean doLog) {
+    throwIfNull(flag, "flag must not be null");
+    throwIfNull(flagKey, "flagKey must not be null");
+    throwIfNull(subjectKey, "subjectKey must not be null");
+    throwIfNull(subjectAttributes, "subjectAttributes must not be null");
+    throwIfNull(extraLogging, "extraLogging must not be null");
+
+    this.flag = flag;
     this.flagKey = flagKey;
     this.subjectKey = subjectKey;
     this.subjectAttributes = subjectAttributes;
-    this.allocationKey = allocationKey;
-    this.variation = variation;
+    this.allocationKeyAndVariation = allocationKeyAndVariation;
     this.extraLogging = extraLogging;
     this.doLog = doLog;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "FlagEvaluationResult{" +
-      "flagKey='" + flagKey + '\'' +
+      "flag='" + flag + '\'' +
+      ", flagKey='" + flagKey + '\'' +
       ", subjectKey='" + subjectKey + '\'' +
       ", subjectAttributes=" + subjectAttributes +
-      ", allocationKey='" + allocationKey + '\'' +
-      ", variation=" + variation +
+      ", allocationKeyAndVariation='" + allocationKeyAndVariation + '\'' +
       ", extraLogging=" + extraLogging +
       ", doLog=" + doLog +
       '}';
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     FlagEvaluationResult that = (FlagEvaluationResult) o;
     return doLog == that.doLog
+            && Objects.equals(flag, that.flag)
             && Objects.equals(flagKey, that.flagKey)
             && Objects.equals(subjectKey, that.subjectKey)
             && Objects.equals(subjectAttributes, that.subjectAttributes)
-            && Objects.equals(allocationKey, that.allocationKey)
-            && Objects.equals(variation, that.variation)
+            && Objects.equals(allocationKeyAndVariation, that.allocationKeyAndVariation)
             && Objects.equals(extraLogging, that.extraLogging);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(flagKey, subjectKey, subjectAttributes, allocationKey, variation, extraLogging, doLog);
+    return Objects.hash(flag, flagKey, subjectKey, subjectAttributes, allocationKeyAndVariation, extraLogging, doLog);
   }
 
+  @NotNull
+  public FlagConfig getFlag() {
+    return flag;
+  }
+
+  @NotNull
   public String getFlagKey() {
     return flagKey;
   }
 
+  @NotNull
   public String getSubjectKey() {
     return subjectKey;
   }
 
+  @NotNull
   public Attributes getSubjectAttributes() {
     return subjectAttributes;
   }
 
+  @Nullable
+  public FlagEvaluationAllocationKeyAndVariation getAllocationKeyAndVariation() {
+    return allocationKeyAndVariation;
+  }
+
+  @Nullable
   public String getAllocationKey() {
-    return allocationKey;
+    return allocationKeyAndVariation != null ? allocationKeyAndVariation.allocationKey : null;
   }
 
+  @Nullable
   public Variation getVariation() {
-    return variation;
+    return allocationKeyAndVariation != null ? allocationKeyAndVariation.variation : null;
   }
 
+  @NotNull
   public Map<String, String> getExtraLogging() {
     return extraLogging;
   }

--- a/src/main/java/cloud/eppo/FlagEvaluator.java
+++ b/src/main/java/cloud/eppo/FlagEvaluator.java
@@ -2,6 +2,12 @@ package cloud.eppo;
 
 import static cloud.eppo.Utils.base64Decode;
 import static cloud.eppo.Utils.getShard;
+import static cloud.eppo.Utils.notNullBase64Decode;
+import static cloud.eppo.Utils.throwIfEmptyOrNull;
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import cloud.eppo.api.Attributes;
 import cloud.eppo.api.EppoValue;
@@ -11,6 +17,8 @@ import cloud.eppo.ufc.dto.FlagConfig;
 import cloud.eppo.ufc.dto.Shard;
 import cloud.eppo.ufc.dto.Split;
 import cloud.eppo.ufc.dto.Variation;
+import cloud.eppo.ufc.dto.VariationType;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -19,22 +27,28 @@ import java.util.Map;
 
 public class FlagEvaluator {
 
+  @NotNull
   public static FlagEvaluationResult evaluateFlag(
-      FlagConfig flag,
-      String flagKey,
-      String subjectKey,
-      Attributes subjectAttributes,
+      @NotNull FlagConfig flag,
+      @NotNull String flagKey,
+      @NotNull String subjectKey,
+      @NotNull Attributes subjectAttributes,
       boolean isConfigObfuscated) {
-    Date now = new Date();
+    throwIfNull(flag, "flag must not be null");
+    throwIfNull(flagKey, "flagKey must not be null");
+    throwIfNull(subjectKey, "subjectKey must not be null");
+    throwIfNull(subjectAttributes, "subjectAttributes must not be null");
 
-    Variation variation = null;
-    String allocationKey = null;
-    Map<String, String> extraLogging = new HashMap<>();
+    @NotNull final Date now = new Date();
+
+    @Nullable Variation variation = null;
+    @Nullable String allocationKey = null;
+    @NotNull Map<String, String> extraLogging = new HashMap<>();
     boolean doLog = false;
 
     // If flag is disabled; use an empty list of allocations so that the empty result is returned
     // Note: this is a safety check; disabled flags should be filtered upstream
-    List<Allocation> allocationsToConsider =
+    @NotNull final List<Allocation> allocationsToConsider =
         flag.isEnabled() && flag.getAllocations() != null
             ? flag.getAllocations()
             : new LinkedList<>();
@@ -51,7 +65,7 @@ public class FlagEvaluator {
 
       // For convenience, we will automatically include the subject key as the "id" attribute if
       // none is provided
-      Attributes subjectAttributesToEvaluate = new Attributes(subjectAttributes);
+      @NotNull final Attributes subjectAttributesToEvaluate = new Attributes(subjectAttributes);
       if (!subjectAttributesToEvaluate.containsKey("id")) {
         subjectAttributesToEvaluate.put("id", subjectKey);
       }
@@ -66,7 +80,7 @@ public class FlagEvaluator {
       }
 
       // This allocation has matched; find variation
-      for (Split split : allocation.getSplits()) {
+      for (@NotNull final Split split : allocation.getSplits()) {
         if (allShardsMatch(split, subjectKey, flag.getTotalShards(), isConfigObfuscated)) {
           // Variation and extra logging is determined by the relevant split
           variation = flag.getVariations().get(split.getVariationKey());
@@ -90,29 +104,38 @@ public class FlagEvaluator {
     if (isConfigObfuscated) {
       // Need to unobfuscate for the returned evaluation result
       if (allocationKey != null) {
-        allocationKey = base64Decode(allocationKey);
+        allocationKey = notNullBase64Decode(allocationKey);
       }
       if (variation != null) {
-        String key = base64Decode(variation.getKey());
-        EppoValue decodedValue = EppoValue.nullValue();
-        if (!variation.getValue().isNull()) {
-          String stringValue = base64Decode(variation.getValue().stringValue());
-          switch (flag.getVariationType()) {
-            case BOOLEAN:
-              decodedValue = EppoValue.valueOf("true".equals(stringValue));
-              break;
-            case INTEGER:
-            case NUMERIC:
-              decodedValue = EppoValue.valueOf(Double.parseDouble(stringValue));
-              break;
-            case STRING:
-            case JSON:
-              decodedValue = EppoValue.valueOf(stringValue);
-              break;
-            default:
-              throw new UnsupportedOperationException(
-                  "Unexpected variation type for decoding obfuscated variation: "
-                      + flag.getVariationType());
+        @NotNull final String key = notNullBase64Decode(variation.getKey());
+        @NotNull final EppoValue decodedValue;
+        if (variation.getValue().isNull()) {
+          decodedValue = EppoValue.nullValue();
+        } else {
+          @NotNull final String stringValue = notNullBase64Decode(variation.getValue().stringValue());
+          @Nullable final VariationType variationType = flag.getVariationType();
+          if (variationType == null) {
+            throw new UnsupportedOperationException(
+                    "Unexpected variation type for decoding obfuscated variation: "
+                            + variationType);
+          } else {
+            switch (variationType) {
+              case BOOLEAN:
+                decodedValue = EppoValue.valueOf("true".equals(stringValue));
+                break;
+              case INTEGER:
+              case NUMERIC:
+                decodedValue = EppoValue.valueOf(Double.parseDouble(stringValue));
+                break;
+              case STRING:
+              case JSON:
+                decodedValue = EppoValue.valueOf(stringValue);
+                break;
+              default:
+                throw new UnsupportedOperationException(
+                        "Unexpected variation type for decoding obfuscated variation: "
+                                + variationType);
+            }
           }
         }
         variation = new Variation(key, decodedValue);
@@ -120,11 +143,11 @@ public class FlagEvaluator {
 
       // Deobfuscate extraLogging if present
       if (extraLogging != null && !extraLogging.isEmpty()) {
-        Map<String, String> deobfuscatedExtraLogging = new HashMap<>();
-        for (Map.Entry<String, String> entry : extraLogging.entrySet()) {
+        @NotNull final Map<String, String> deobfuscatedExtraLogging = new HashMap<>();
+        for (@NotNull final Map.Entry<String, String> entry : extraLogging.entrySet()) {
           try {
-            String deobfuscatedKey = base64Decode(entry.getKey());
-            String deobfuscatedValue = base64Decode(entry.getValue());
+            @Nullable final String deobfuscatedKey = base64Decode(entry.getKey());
+            @Nullable final String deobfuscatedValue = base64Decode(entry.getValue());
             deobfuscatedExtraLogging.put(deobfuscatedKey, deobfuscatedValue);
           } catch (Exception e) {
             // If deobfuscation fails, keep the original key-value pair
@@ -135,18 +158,26 @@ public class FlagEvaluator {
       }
     }
 
+    @Nullable final FlagEvaluationAllocationKeyAndVariation allocationKeyAndVariation;
+    if (allocationKey != null && variation != null) {
+      // if allocationKey != null then variation is also != null
+      allocationKeyAndVariation = new FlagEvaluationAllocationKeyAndVariation(allocationKey, variation);
+    } else {
+      allocationKeyAndVariation = null;
+    }
+
     return new FlagEvaluationResult(
-        flagKey, subjectKey, subjectAttributes, allocationKey, variation, extraLogging, doLog);
+        flag, flagKey, subjectKey, subjectAttributes, allocationKeyAndVariation, extraLogging, doLog);
   }
 
   private static boolean allShardsMatch(
-      Split split, String subjectKey, int totalShards, boolean isObfuscated) {
+      @NotNull Split split, @NotNull String subjectKey, int totalShards, boolean isObfuscated) {
     if (split.getShards() == null || split.getShards().isEmpty()) {
       // Default to matching if no explicit shards
       return true;
     }
 
-    for (Shard shard : split.getShards()) {
+    for (@NotNull final Shard shard : split.getShards()) {
       if (!matchesShard(shard, subjectKey, totalShards, isObfuscated)) {
         return false;
       }
@@ -157,14 +188,16 @@ public class FlagEvaluator {
   }
 
   private static boolean matchesShard(
-      Shard shard, String subjectKey, int totalShards, boolean isObfuscated) {
-    String salt = shard.getSalt();
+      @NotNull Shard shard, @NotNull String subjectKey, int totalShards, boolean isObfuscated) {
+    @NotNull final String salt;
     if (isObfuscated) {
-      salt = base64Decode(salt);
+      salt = notNullBase64Decode(shard.getSalt());
+    } else {
+      salt = shard.getSalt();
     }
-    String hashKey = salt + "-" + subjectKey;
-    int assignedShard = getShard(hashKey, totalShards);
-    for (ShardRange range : shard.getRanges()) {
+    @NotNull final String hashKey = salt + "-" + subjectKey;
+    final int assignedShard = getShard(hashKey, totalShards);
+    for (@NotNull final ShardRange range : shard.getRanges()) {
       if (assignedShard >= range.getStart() && assignedShard < range.getEnd()) {
         return true;
       }

--- a/src/main/java/cloud/eppo/ValuedFlagEvaluationResult.java
+++ b/src/main/java/cloud/eppo/ValuedFlagEvaluationResult.java
@@ -1,0 +1,73 @@
+package cloud.eppo;
+
+import static cloud.eppo.Utils.throwIfNull;
+import static cloud.eppo.ValuedFlagEvaluationResultType.OK;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+import cloud.eppo.api.EppoValue;
+
+/**
+ * The result of BaseEppoClient.getTypedAssignmentResult().
+ * If BaseEppoClient can't call FlagEvaluator.evaluateFlag(),
+ * then evaluationResult will be null.
+ */
+public class ValuedFlagEvaluationResult {
+  @NotNull private final EppoValue value;
+  @Nullable private final FlagEvaluationResult evaluationResult;
+  @NotNull private final ValuedFlagEvaluationResultType type;
+
+  public ValuedFlagEvaluationResult(
+      @NotNull EppoValue value,
+      @Nullable FlagEvaluationResult evaluationResult,
+      @NotNull ValuedFlagEvaluationResultType type) {
+    throwIfNull(value, "value must not be null");
+    throwIfNull(type, "type must not be null");
+    if (type == OK) {
+      throwIfNull(evaluationResult, "evaluationResult must not be null if type is " + OK);
+    }
+
+    this.value = value;
+    this.evaluationResult = evaluationResult;
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    ValuedFlagEvaluationResult that = (ValuedFlagEvaluationResult) o;
+    return Objects.equals(value, that.value) && Objects.equals(evaluationResult, that.evaluationResult) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, evaluationResult, type);
+  }
+
+  @Override
+  public String toString() {
+    return "ValuedFlagEvaluationResult{" +
+      "value=" + value +
+      ", evaluationResult=" + evaluationResult +
+      ", type=" + type +
+      '}';
+  }
+
+  @NotNull
+  public EppoValue getValue() {
+    return value;
+  }
+
+  @Nullable
+  public FlagEvaluationResult getEvaluationResult() {
+    return evaluationResult;
+  }
+
+  @NotNull
+  public ValuedFlagEvaluationResultType getType() {
+    return type;
+  }
+}

--- a/src/main/java/cloud/eppo/ValuedFlagEvaluationResultType.java
+++ b/src/main/java/cloud/eppo/ValuedFlagEvaluationResultType.java
@@ -1,0 +1,14 @@
+package cloud.eppo;
+
+/**
+ * Possible reasons for a default value from a call to BaseEppoClient.getTypedAssignmentResult()
+ */
+public enum ValuedFlagEvaluationResultType {
+  NO_FLAG_CONFIG,
+  FLAG_DISABLED,
+  BAD_VARIATION_TYPE,
+  BAD_VALUE_TYPE,
+  NO_ALLOCATION,
+  OK,
+  ;
+}

--- a/src/main/java/cloud/eppo/api/EppoValue.java
+++ b/src/main/java/cloud/eppo/api/EppoValue.java
@@ -1,123 +1,184 @@
 package cloud.eppo.api;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import cloud.eppo.ufc.dto.EppoValueType;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
 public class EppoValue {
-  protected final EppoValueType type;
-  protected Boolean boolValue;
-  protected Double doubleValue;
-  protected String stringValue;
-  protected List<String> stringArrayValue;
+  @NotNull protected final EppoValueType type;
+  @Nullable protected final Boolean boolValue;
+  @Nullable protected final Double doubleValue;
+  @Nullable protected final String stringValue;
+  @Nullable protected final List<String> stringArrayValue;
 
   protected EppoValue() {
-    this.type = EppoValueType.NULL;
+    this(
+      EppoValueType.NULL,
+      null,
+      null,
+      null,
+      null
+    );
   }
 
   protected EppoValue(boolean boolValue) {
-    this.boolValue = boolValue;
-    this.type = EppoValueType.BOOLEAN;
+    this(
+      EppoValueType.BOOLEAN,
+      boolValue,
+      null,
+      null,
+      null
+    );
   }
 
   protected EppoValue(double doubleValue) {
+    this(
+      EppoValueType.NUMBER,
+      null,
+      doubleValue,
+      null,
+      null
+    );
+  }
+
+  protected EppoValue(@NotNull String stringValue) {
+    this(
+      EppoValueType.STRING,
+      null,
+      null,
+      throwIfNull(stringValue, "stringValue must not be null"),
+      null
+    );
+  }
+
+  protected EppoValue(@NotNull List<String> stringArrayValue) {
+    this(
+      EppoValueType.ARRAY_OF_STRING,
+      null,
+      null,
+      null,
+      throwIfNull(stringArrayValue, "stringArrayValue must not be null")
+    );
+  }
+
+  private EppoValue(
+      @NotNull EppoValueType type,
+      @Nullable Boolean boolValue,
+      @Nullable Double doubleValue,
+      @Nullable String stringValue,
+      @Nullable List<String> stringArrayValue) {
+    throwIfNull(type, "type must not be null");
+
+    this.type = type;
+    this.boolValue = boolValue;
     this.doubleValue = doubleValue;
-    this.type = EppoValueType.NUMBER;
-  }
-
-  protected EppoValue(String stringValue) {
     this.stringValue = stringValue;
-    this.type = EppoValueType.STRING;
-  }
-
-  protected EppoValue(List<String> stringArrayValue) {
     this.stringArrayValue = stringArrayValue;
-    this.type = EppoValueType.ARRAY_OF_STRING;
   }
 
+  @NotNull
   public static EppoValue nullValue() {
     return new EppoValue();
   }
 
+  @NotNull
   public static EppoValue valueOf(boolean boolValue) {
     return new EppoValue(boolValue);
   }
 
+  @NotNull
   public static EppoValue valueOf(double doubleValue) {
     return new EppoValue(doubleValue);
   }
 
-  public static EppoValue valueOf(String stringValue) {
+  @NotNull
+  public static EppoValue valueOf(@NotNull String stringValue) {
     return new EppoValue(stringValue);
   }
 
-  public static EppoValue valueOf(List<String> value) {
+  @NotNull
+  public static EppoValue valueOf(@NotNull List<String> value) {
     return new EppoValue(value);
   }
 
   public boolean booleanValue() {
-    return this.boolValue;
+    @Nullable final Boolean boolValue = this.boolValue;
+    if (boolValue == null) {
+      throw new NullPointerException("boolValue is null for type: " + type);
+    }
+    return boolValue;
+  }
+
+  public int intValue() {
+    @Nullable final Double doubleValue = this.doubleValue;
+    if (doubleValue == null) {
+      throw new NullPointerException("doubleValue is null for type: " + type);
+    }
+    return doubleValue.intValue();
   }
 
   public double doubleValue() {
-    return this.doubleValue;
+    @Nullable final Double doubleValue = this.doubleValue;
+    if (doubleValue == null) {
+      throw new NullPointerException("doubleValue is null for type: " + type);
+    }
+    return doubleValue;
   }
 
+  @NotNull
   public String stringValue() {
-    return this.stringValue;
+    @Nullable final String stringValue = this.stringValue;
+    if (stringValue == null) {
+      throw new NullPointerException("stringValue is null for type: " + type);
+    }
+    return stringValue;
   }
 
   public List<String> stringArrayValue() {
-    return this.stringArrayValue;
+    @Nullable final List<String> stringArrayValue = this.stringArrayValue;
+    if (stringArrayValue == null) {
+      throw new NullPointerException("stringArrayValue is null for type: " + type);
+    }
+    return stringArrayValue;
   }
 
   public boolean isNull() {
-    return type == EppoValueType.NULL;
+    return type.isNull();
   }
 
   public boolean isBoolean() {
-    return this.type == EppoValueType.BOOLEAN;
+    return this.type.isBoolean();
   }
 
   public boolean isNumeric() {
-    return this.type == EppoValueType.NUMBER;
+    return this.type.isNumeric();
   }
 
   public boolean isString() {
-    return this.type == EppoValueType.STRING;
+    return this.type.isString();
   }
 
   public boolean isStringArray() {
-    return type == EppoValueType.ARRAY_OF_STRING;
+    return type.isStringArray();
   }
 
+  @NotNull
   public EppoValueType getType() {
     return type;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
-    switch (this.type) {
-      case BOOLEAN:
-        return this.boolValue.toString();
-      case NUMBER:
-        return this.doubleValue.toString();
-      case STRING:
-        return this.stringValue;
-      case ARRAY_OF_STRING:
-        // Android21 back-compatability
-        return joinStringArray(this.stringArrayValue);
-      case NULL:
-        return "";
-      default:
-        throw new UnsupportedOperationException(
-            "Cannot stringify Eppo Value type " + this.type.name());
-    }
+    return type.toString(boolValue, doubleValue, stringValue, stringArrayValue);
   }
 
   @Override
-  public boolean equals(Object otherObject) {
+  public boolean equals(@Nullable Object otherObject) {
     if (this == otherObject) {
       return true;
     }
@@ -135,22 +196,5 @@ public class EppoValue {
   @Override
   public int hashCode() {
     return Objects.hash(type, boolValue, doubleValue, stringValue, stringArrayValue);
-  }
-
-  /** This method is to allow for Android 21 support; String.join was introduced in API 26 */
-  private static String joinStringArray(List<String> stringArray) {
-    if (stringArray == null || stringArray.isEmpty()) {
-      return "";
-    }
-    String delimiter = ", ";
-    StringBuilder stringBuilder = new StringBuilder();
-    Iterator<String> iterator = stringArray.iterator();
-    while (iterator.hasNext()) {
-      stringBuilder.append(iterator.next());
-      if (iterator.hasNext()) {
-        stringBuilder.append(delimiter);
-      }
-    }
-    return stringBuilder.toString();
   }
 }

--- a/src/main/java/cloud/eppo/cache/AssignmentCacheEntry.java
+++ b/src/main/java/cloud/eppo/cache/AssignmentCacheEntry.java
@@ -1,34 +1,42 @@
 package cloud.eppo.cache;
 
+import static cloud.eppo.Utils.throwIfNull;
+
 import cloud.eppo.logging.Assignment;
 import cloud.eppo.logging.BanditAssignment;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class AssignmentCacheEntry {
-  private final AssignmentCacheKey key;
-  private final AssignmentCacheValue value;
+  @NotNull private final AssignmentCacheKey key;
+  @NotNull private final AssignmentCacheValue value;
 
   public AssignmentCacheEntry(
       @NotNull AssignmentCacheKey key, @NotNull AssignmentCacheValue value) {
+    throwIfNull(key, "key must not be null");
+    throwIfNull(value, "value must not be null");
+
     this.key = key;
     this.value = value;
   }
 
-  public static AssignmentCacheEntry fromVariationAssignment(Assignment assignment) {
+  @NotNull
+  public static AssignmentCacheEntry fromVariationAssignment(@NotNull Assignment assignment) {
     return new AssignmentCacheEntry(
         new AssignmentCacheKey(assignment.getSubject(), assignment.getFeatureFlag()),
         new VariationCacheValue(assignment.getAllocation(), assignment.getVariation()));
   }
 
-  public static AssignmentCacheEntry fromBanditAssignment(BanditAssignment assignment) {
+  @NotNull
+  public static AssignmentCacheEntry fromBanditAssignment(@NotNull BanditAssignment assignment) {
     return new AssignmentCacheEntry(
         new AssignmentCacheKey(assignment.getSubject(), assignment.getFeatureFlag()),
         new BanditCacheValue(assignment.getBandit(), assignment.getAction()));
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     AssignmentCacheEntry that = (AssignmentCacheEntry) o;
     return Objects.equals(key, that.key)
@@ -40,7 +48,7 @@ public class AssignmentCacheEntry {
     return Objects.hash(key, value);
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "AssignmentCacheEntry{" +
       "key=" + key +

--- a/src/main/java/cloud/eppo/ufc/dto/Allocation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Allocation.java
@@ -1,25 +1,35 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfEmptyOrNull;
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public class Allocation {
-  private String key;
-  private Set<TargetingRule> rules;
-  private Date startAt;
-  private Date endAt;
-  private List<Split> splits;
+  @NotNull private String key;
+  @NotNull private Set<TargetingRule> rules;
+  @Nullable private Date startAt;
+  @Nullable private Date endAt;
+  @NotNull private List<Split> splits;
   private boolean doLog;
 
   public Allocation(
-      String key,
-      Set<TargetingRule> rules,
-      Date startAt,
-      Date endAt,
-      List<Split> splits,
+      @NotNull String key,
+      @NotNull Set<TargetingRule> rules,
+      @Nullable Date startAt,
+      @Nullable Date endAt,
+      @NotNull List<Split> splits,
       boolean doLog) {
+    throwIfNull(key, "key must not be null");
+    throwIfNull(rules, "rules must not be null");
+    throwIfNull(splits, "splits must not be null");
+
     this.key = key;
     this.rules = rules;
     this.startAt = startAt;
@@ -28,7 +38,7 @@ public class Allocation {
     this.doLog = doLog;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "Allocation{" +
       "key='" + key + '\'' +
@@ -41,7 +51,7 @@ public class Allocation {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     Allocation that = (Allocation) o;
     return doLog == that.doLog
@@ -57,43 +67,54 @@ public class Allocation {
     return Objects.hash(key, rules, startAt, endAt, splits, doLog);
   }
 
+  @NotNull
   public String getKey() {
     return key;
   }
 
-  public void setKey(String key) {
+  public void setKey(@NotNull String key) {
+    throwIfEmptyOrNull(key, "key must not be null");
+
     this.key = key;
   }
 
+  @NotNull
   public Set<TargetingRule> getRules() {
     return rules;
   }
 
-  public void setRules(Set<TargetingRule> rules) {
+  public void setRules(@NotNull Set<TargetingRule> rules) {
+    throwIfNull(rules, "rules must not be null");
+
     this.rules = rules;
   }
 
+  @Nullable
   public Date getStartAt() {
     return startAt;
   }
 
-  public void setStartAt(Date startAt) {
+  public void setStartAt(@Nullable Date startAt) {
     this.startAt = startAt;
   }
 
+  @Nullable
   public Date getEndAt() {
     return endAt;
   }
 
-  public void setEndAt(Date endAt) {
+  public void setEndAt(@Nullable Date endAt) {
     this.endAt = endAt;
   }
 
+  @NotNull
   public List<Split> getSplits() {
     return splits;
   }
 
-  public void setSplits(List<Split> splits) {
+  public void setSplits(@NotNull List<Split> splits) {
+    throwIfNull(splits, "splits must not be null");
+
     this.splits = splits;
   }
 

--- a/src/main/java/cloud/eppo/ufc/dto/BanditFlagVariation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/BanditFlagVariation.java
@@ -1,20 +1,31 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Objects;
 
 public class BanditFlagVariation {
-  private final String banditKey;
-  private final String flagKey;
-  private final String allocationKey;
-  private final String variationKey;
-  private final String variationValue;
+  @NotNull private final String banditKey;
+  @NotNull private final String flagKey;
+  @NotNull private final String allocationKey;
+  @NotNull private final String variationKey;
+  @NotNull private final String variationValue;
 
   public BanditFlagVariation(
-      String banditKey,
-      String flagKey,
-      String allocationKey,
-      String variationKey,
-      String variationValue) {
+      @NotNull String banditKey,
+      @NotNull String flagKey,
+      @NotNull String allocationKey,
+      @NotNull String variationKey,
+      @NotNull String variationValue) {
+    throwIfNull(banditKey, "banditKey must not be null");
+    throwIfNull(flagKey, "flagKey must not be null");
+    throwIfNull(allocationKey, "allocationKey must not be null");
+    throwIfNull(variationKey, "variationKey must not be null");
+    throwIfNull(variationValue, "variationValue must not be null");
+
     this.banditKey = banditKey;
     this.flagKey = flagKey;
     this.allocationKey = allocationKey;
@@ -22,7 +33,7 @@ public class BanditFlagVariation {
     this.variationValue = variationValue;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "BanditFlagVariation{" +
       "banditKey='" + banditKey + '\'' +
@@ -34,7 +45,7 @@ public class BanditFlagVariation {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     BanditFlagVariation that = (BanditFlagVariation) o;
     return Objects.equals(banditKey, that.banditKey)
@@ -49,22 +60,27 @@ public class BanditFlagVariation {
     return Objects.hash(banditKey, flagKey, allocationKey, variationKey, variationValue);
   }
 
+  @NotNull
   public String getBanditKey() {
     return banditKey;
   }
 
+  @NotNull
   public String getFlagKey() {
     return flagKey;
   }
 
+  @NotNull
   public String getAllocationKey() {
     return allocationKey;
   }
 
+  @NotNull
   public String getVariationKey() {
     return variationKey;
   }
 
+  @NotNull
   public String getVariationValue() {
     return variationValue;
   }

--- a/src/main/java/cloud/eppo/ufc/dto/EppoValueType.java
+++ b/src/main/java/cloud/eppo/ufc/dto/EppoValueType.java
@@ -1,9 +1,198 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+import java.util.List;
+
 public enum EppoValueType {
-  NULL,
-  BOOLEAN,
-  NUMBER,
-  STRING,
-  ARRAY_OF_STRING,
+  NULL {
+    public boolean isNull() {
+      return true;
+    }
+
+    public boolean isBoolean() {
+      return false;
+    }
+
+    public boolean isNumeric() {
+      return false;
+    }
+
+    public boolean isString() {
+      return false;
+    }
+
+    public boolean isStringArray() {
+      return false;
+    }
+
+    @Override @NotNull
+    public String toString(
+        @Nullable Boolean boolValue,
+        @Nullable Double doubleValue,
+        @Nullable String stringValue,
+        @Nullable List<String> stringArrayValue) {
+      return "";
+    }
+  },
+  BOOLEAN {
+    public boolean isNull() {
+      return false;
+    }
+
+    public boolean isBoolean() {
+      return true;
+    }
+
+    public boolean isNumeric() {
+      return false;
+    }
+
+    public boolean isString() {
+      return false;
+    }
+
+    public boolean isStringArray() {
+      return false;
+    }
+
+    @Override @NotNull
+    public String toString(
+        @Nullable Boolean boolValue,
+        @Nullable Double doubleValue,
+        @Nullable String stringValue,
+        @Nullable List<String> stringArrayValue) {
+      throwIfNull(boolValue, "boolValue must not be null");
+      return boolValue.toString();
+    }
+  },
+  NUMBER {
+    public boolean isNull() {
+      return false;
+    }
+
+    public boolean isBoolean() {
+      return false;
+    }
+
+    public boolean isNumeric() {
+      return true;
+    }
+
+    public boolean isString() {
+      return false;
+    }
+
+    public boolean isStringArray() {
+      return false;
+    }
+
+    @Override @NotNull
+    public String toString(
+        @Nullable Boolean boolValue,
+        @Nullable Double doubleValue,
+        @Nullable String stringValue,
+        @Nullable List<String> stringArrayValue) {
+      throwIfNull(doubleValue, "doubleValue must not be null");
+      return doubleValue.toString();
+    }
+  },
+  STRING {
+    public boolean isNull() {
+      return false;
+    }
+
+    public boolean isBoolean() {
+      return false;
+    }
+
+    public boolean isNumeric() {
+      return false;
+    }
+
+    public boolean isString() {
+      return true;
+    }
+
+    public boolean isStringArray() {
+      return false;
+    }
+
+    @Override @NotNull
+    public String toString(
+        @Nullable Boolean boolValue,
+        @Nullable Double doubleValue,
+        @Nullable String stringValue,
+        @Nullable List<String> stringArrayValue) {
+      throwIfNull(stringValue, "stringValue must not be null");
+      return stringValue;
+    }
+  },
+  ARRAY_OF_STRING {
+    public boolean isNull() {
+      return false;
+    }
+
+    public boolean isBoolean() {
+      return false;
+    }
+
+    public boolean isNumeric() {
+      return false;
+    }
+
+    public boolean isString() {
+      return false;
+    }
+
+    public boolean isStringArray() {
+      return true;
+    }
+
+    @Override @NotNull
+    public String toString(
+        @Nullable Boolean boolValue,
+        @Nullable Double doubleValue,
+        @Nullable String stringValue,
+        @Nullable List<String> stringArrayValue) {
+      throwIfNull(stringArrayValue, "stringArray must not be null");
+      return EppoValueType.joinStringArray(stringArrayValue);
+    }
+  },
+  ;
+
+  public abstract boolean isNull();
+  public abstract boolean isBoolean();
+  public abstract boolean isNumeric();
+  public abstract boolean isString();
+  public abstract boolean isStringArray();
+
+  @NotNull
+  public abstract String toString(
+      @Nullable Boolean boolValue,
+      @Nullable Double doubleValue,
+      @Nullable String stringValue,
+      @Nullable List<String> stringArrayValue);
+
+  /** This method is to allow for Android 21 support; String.join was introduced in API 26 */
+  @NotNull
+  private static String joinStringArray(@NotNull List<String> stringArray) {
+    if (stringArray.isEmpty()) {
+      return "";
+    }
+    String delimiter = ", ";
+    StringBuilder stringBuilder = new StringBuilder();
+    Iterator<String> iterator = stringArray.iterator();
+    while (iterator.hasNext()) {
+      stringBuilder.append(iterator.next());
+      if (iterator.hasNext()) {
+        stringBuilder.append(delimiter);
+      }
+    }
+    return stringBuilder.toString();
+  }
 }

--- a/src/main/java/cloud/eppo/ufc/dto/FlagConfig.java
+++ b/src/main/java/cloud/eppo/ufc/dto/FlagConfig.java
@@ -1,33 +1,46 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public class FlagConfig {
-  private final String key;
+  @NotNull private final String key;
   private final boolean enabled;
   private final int totalShards;
-  private final VariationType variationType;
-  private final Map<String, Variation> variations;
-  private final List<Allocation> allocations;
+  @Nullable private final VariationType variationType;
+  @NotNull private final Map<String, Variation> variations;
+  @NotNull private final List<String> sortedVariationKeys;
+  @NotNull private final List<Allocation> allocations;
 
   public FlagConfig(
-      String key,
+      @NotNull String key,
       boolean enabled,
       int totalShards,
-      VariationType variationType,
-      Map<String, Variation> variations,
-      List<Allocation> allocations) {
+      @Nullable VariationType variationType,
+      @NotNull Map<String, Variation> variations,
+      @NotNull List<String> sortedVariationKeys,
+      @NotNull List<Allocation> allocations) {
+    throwIfNull(key, "key must not be null");
+    throwIfNull(variations, "variations must not be null");
+    throwIfNull(sortedVariationKeys, "sortedVariationKeys must not be null");
+    throwIfNull(allocations, "allocations must not be null");
+
     this.key = key;
     this.enabled = enabled;
     this.totalShards = totalShards;
     this.variationType = variationType;
     this.variations = variations;
+    this.sortedVariationKeys = sortedVariationKeys;
     this.allocations = allocations;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "FlagConfig{" +
       "key='" + key + '\'' +
@@ -35,12 +48,13 @@ public class FlagConfig {
       ", totalShards=" + totalShards +
       ", variationType=" + variationType +
       ", variations=" + variations +
+      ", sortedVariationKeys=" + sortedVariationKeys +
       ", allocations=" + allocations +
       '}';
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     FlagConfig that = (FlagConfig) o;
     return enabled == that.enabled
@@ -48,14 +62,16 @@ public class FlagConfig {
             && Objects.equals(key, that.key)
             && variationType == that.variationType
             && Objects.equals(variations, that.variations)
+            && Objects.equals(sortedVariationKeys, that.sortedVariationKeys)
             && Objects.equals(allocations, that.allocations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, enabled, totalShards, variationType, variations, allocations);
+    return Objects.hash(key, enabled, totalShards, variationType, variations, sortedVariationKeys, allocations);
   }
 
+  @NotNull
   public String getKey() {
     return this.key;
   }
@@ -68,14 +84,22 @@ public class FlagConfig {
     return enabled;
   }
 
+  @Nullable
   public VariationType getVariationType() {
     return variationType;
   }
 
+  @NotNull
   public Map<String, Variation> getVariations() {
     return variations;
   }
 
+  @NotNull
+  public List<String> getSortedVariationKeys() {
+    return sortedVariationKeys;
+  }
+
+  @NotNull
   public List<Allocation> getAllocations() {
     return allocations;
   }

--- a/src/main/java/cloud/eppo/ufc/dto/OperatorType.java
+++ b/src/main/java/cloud/eppo/ufc/dto/OperatorType.java
@@ -1,6 +1,10 @@
 package cloud.eppo.ufc.dto;
 
 import static cloud.eppo.Utils.getMD5Hex;
+import static cloud.eppo.Utils.throwIfEmptyOrNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,36 +20,41 @@ public enum OperatorType {
   NOT_ONE_OF("NOT_ONE_OF"),
   IS_NULL("IS_NULL");
 
-  public final String value;
-  private static final Map<String, OperatorType> valuesToOperatorType =
+  @NotNull public final String value;
+  @NotNull private static final Map<String, OperatorType> valuesToOperatorType =
       buildValueToOperatorTypeMap();
-  private static final Map<String, OperatorType> hashesToOperatorType =
+  @NotNull private static final Map<String, OperatorType> hashesToOperatorType =
       buildHashToOperatorTypeMap();
 
+  @NotNull
   private static Map<String, OperatorType> buildValueToOperatorTypeMap() {
-    Map<String, OperatorType> result = new HashMap<>();
-    for (OperatorType type : OperatorType.values()) {
+    @NotNull final Map<String, OperatorType> result = new HashMap<>();
+    for (@NotNull final OperatorType type : OperatorType.values()) {
       result.put(type.value, type);
     }
     return result;
   }
 
+  @NotNull
   private static Map<String, OperatorType> buildHashToOperatorTypeMap() {
-    Map<String, OperatorType> result = new HashMap<>();
-    for (OperatorType type : OperatorType.values()) {
+    @NotNull final Map<String, OperatorType> result = new HashMap<>();
+    for (@NotNull final OperatorType type : OperatorType.values()) {
       result.put(getMD5Hex(type.value), type);
     }
     return result;
   }
 
-  OperatorType(String value) {
+  OperatorType(@NotNull String value) {
+    throwIfEmptyOrNull(value, "value must not be null");
+
     this.value = value;
   }
 
+  @Nullable
   public static OperatorType fromString(String value) {
     // First we try obfuscated lookup as in client situations we'll care more about ingestion
     // performance
-    OperatorType type = hashesToOperatorType.get(value);
+    @Nullable OperatorType type = hashesToOperatorType.get(value);
     // Then we'll try non-obfuscated lookup
     if (type == null) {
       type = valuesToOperatorType.get(value);

--- a/src/main/java/cloud/eppo/ufc/dto/Shard.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Shard.java
@@ -1,20 +1,28 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import cloud.eppo.model.ShardRange;
 
 import java.util.Objects;
 import java.util.Set;
 
 public class Shard {
-  private final String salt;
-  private final Set<ShardRange> ranges;
+  @NotNull private final String salt;
+  @NotNull private final Set<ShardRange> ranges;
 
-  public Shard(String salt, Set<ShardRange> ranges) {
+  public Shard(@NotNull String salt, @NotNull Set<ShardRange> ranges) {
+    throwIfNull(salt, "salt must not be null");
+    throwIfNull(ranges, "ranges must not be null");
+
     this.salt = salt;
     this.ranges = ranges;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "Shard{" +
       "salt='" + salt + '\'' +
@@ -23,7 +31,7 @@ public class Shard {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     Shard shard = (Shard) o;
     return Objects.equals(salt, shard.salt)
@@ -35,10 +43,12 @@ public class Shard {
     return Objects.hash(salt, ranges);
   }
 
+  @NotNull
   public String getSalt() {
     return salt;
   }
 
+  @NotNull
   public Set<ShardRange> getRanges() {
     return ranges;
   }

--- a/src/main/java/cloud/eppo/ufc/dto/Split.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Split.java
@@ -1,21 +1,33 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 public class Split {
-  private final String variationKey;
-  private final Set<Shard> shards;
-  private final Map<String, String> extraLogging;
+  @NotNull private final String variationKey;
+  @NotNull private final Set<Shard> shards;
+  @NotNull private final Map<String, String> extraLogging;
 
-  public Split(String variationKey, Set<Shard> shards, Map<String, String> extraLogging) {
+  public Split(
+      @NotNull String variationKey,
+      @NotNull Set<Shard> shards,
+      @NotNull Map<String, String> extraLogging) {
+    throwIfNull(variationKey, "variationKey must not be null");
+    throwIfNull(shards, "shards must not be null");
+    throwIfNull(extraLogging, "extraLogging must not be null");
+
     this.variationKey = variationKey;
     this.shards = shards;
     this.extraLogging = extraLogging;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "Split{" +
       "variationKey='" + variationKey + '\'' +
@@ -25,7 +37,7 @@ public class Split {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     Split split = (Split) o;
     return Objects.equals(variationKey, split.variationKey)
@@ -38,14 +50,17 @@ public class Split {
     return Objects.hash(variationKey, shards, extraLogging);
   }
 
+  @NotNull
   public String getVariationKey() {
     return variationKey;
   }
 
+  @NotNull
   public Set<Shard> getShards() {
     return shards;
   }
 
+  @NotNull
   public Map<String, String> getExtraLogging() {
     return extraLogging;
   }

--- a/src/main/java/cloud/eppo/ufc/dto/TargetingCondition.java
+++ b/src/main/java/cloud/eppo/ufc/dto/TargetingCondition.java
@@ -1,21 +1,33 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Objects;
 
 import cloud.eppo.api.EppoValue;
 
 public class TargetingCondition {
-  private final OperatorType operator;
-  private final String attribute;
-  private final EppoValue value;
+  @NotNull private final OperatorType operator;
+  @NotNull private final String attribute;
+  @NotNull private final EppoValue value;
 
-  public TargetingCondition(OperatorType operator, String attribute, EppoValue value) {
+  public TargetingCondition(
+      @NotNull OperatorType operator,
+      @NotNull String attribute,
+      @NotNull EppoValue value) {
+    throwIfNull(operator, "operator must not be null");
+    throwIfNull(attribute, "attribute must not be null");
+    throwIfNull(value, "value must not be null");
+
     this.operator = operator;
     this.attribute = attribute;
     this.value = value;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "TargetingCondition{" +
       "operator=" + operator +
@@ -25,7 +37,7 @@ public class TargetingCondition {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     TargetingCondition that = (TargetingCondition) o;
     return operator == that.operator
@@ -38,14 +50,17 @@ public class TargetingCondition {
     return Objects.hash(operator, attribute, value);
   }
 
+  @NotNull
   public OperatorType getOperator() {
     return operator;
   }
 
+  @NotNull
   public String getAttribute() {
     return attribute;
   }
 
+  @NotNull
   public EppoValue getValue() {
     return value;
   }

--- a/src/main/java/cloud/eppo/ufc/dto/Variation.java
+++ b/src/main/java/cloud/eppo/ufc/dto/Variation.java
@@ -1,19 +1,27 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Objects;
 
 import cloud.eppo.api.EppoValue;
 
 public class Variation {
-  private final String key;
-  private final EppoValue value;
+  @NotNull private final String key;
+  @NotNull private final EppoValue value;
 
-  public Variation(String key, EppoValue value) {
+  public Variation(@NotNull String key, @NotNull EppoValue value) {
+    throwIfNull(key, "key must not be null");
+    throwIfNull(value, "value must not be null");
+
     this.key = key;
     this.value = value;
   }
 
-  @Override
+  @Override @NotNull
   public String toString() {
     return "Variation{" +
       "key='" + key + '\'' +
@@ -22,7 +30,7 @@ public class Variation {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     Variation variation = (Variation) o;
     return Objects.equals(key, variation.key)
@@ -34,10 +42,12 @@ public class Variation {
     return Objects.hash(key, value);
   }
 
+  @NotNull
   public String getKey() {
     return this.key;
   }
 
+  @NotNull
   public EppoValue getValue() {
     return value;
   }

--- a/src/main/java/cloud/eppo/ufc/dto/VariationType.java
+++ b/src/main/java/cloud/eppo/ufc/dto/VariationType.java
@@ -1,20 +1,28 @@
 package cloud.eppo.ufc.dto;
 
+import static cloud.eppo.Utils.throwIfNull;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public enum VariationType {
   BOOLEAN("BOOLEAN"),
   INTEGER("INTEGER"),
   NUMERIC("NUMERIC"),
   STRING("STRING"),
-  JSON("JSON");
+  JSON("JSON"),
+  ;
 
-  public final String value;
+  @NotNull public final String value;
 
-  VariationType(String value) {
+  VariationType(@NotNull String value) {
+    throwIfNull(value, "value must not be null");
     this.value = value;
   }
 
-  public static VariationType fromString(String value) {
-    for (VariationType type : VariationType.values()) {
+  @Nullable
+  public static VariationType fromString(@NotNull String value) {
+    for (@NotNull final VariationType type : VariationType.values()) {
       if (type.value.equals(value)) {
         return type;
       }

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueDeserializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/EppoValueDeserializer.java
@@ -8,13 +8,16 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class EppoValueDeserializer extends StdDeserializer<EppoValue> {
-  private static final Logger log = LoggerFactory.getLogger(EppoValueDeserializer.class);
+  @NotNull private static final Logger log = LoggerFactory.getLogger(EppoValueDeserializer.class);
 
-  protected EppoValueDeserializer(Class<?> vc) {
+  protected EppoValueDeserializer(@Nullable Class<?> vc) {
     super(vc);
   }
 
@@ -27,13 +30,14 @@ public class EppoValueDeserializer extends StdDeserializer<EppoValue> {
     return deserializeNode(jp.getCodec().readTree(jp));
   }
 
-  public EppoValue deserializeNode(JsonNode node) {
-    EppoValue result;
+  @NotNull
+  public EppoValue deserializeNode(@Nullable JsonNode node) {
+    @NotNull final EppoValue result;
     if (node == null || node.isNull()) {
       result = EppoValue.nullValue();
     } else if (node.isArray()) {
-      List<String> stringArray = new ArrayList<>();
-      for (JsonNode arrayElement : node) {
+      @NotNull final List<String> stringArray = new ArrayList<>();
+      for (@NotNull final JsonNode arrayElement : node) {
         if (arrayElement.isValueNode() && arrayElement.isTextual()) {
           stringArray.add(arrayElement.asText());
         } else {

--- a/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseDeserializer.java
+++ b/src/main/java/cloud/eppo/ufc/dto/adapters/FlagConfigResponseDeserializer.java
@@ -13,6 +13,9 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,64 +87,70 @@ public class FlagConfigResponseDeserializer extends StdDeserializer<FlagConfigRe
     return new FlagConfigResponse(flags, banditReferences, dataFormat);
   }
 
-  private FlagConfig deserializeFlag(JsonNode jsonNode) {
-    String key = jsonNode.get("key").asText();
+  @NotNull
+  private FlagConfig deserializeFlag(@NotNull JsonNode jsonNode) {
+    @NotNull final String key = jsonNode.get("key").asText();
     boolean enabled = jsonNode.get("enabled").asBoolean();
     int totalShards = jsonNode.get("totalShards").asInt();
-    VariationType variationType = VariationType.fromString(jsonNode.get("variationType").asText());
-    Map<String, Variation> variations = deserializeVariations(jsonNode.get("variations"));
-    List<Allocation> allocations = deserializeAllocations(jsonNode.get("allocations"));
+    @Nullable final VariationType variationType = VariationType.fromString(jsonNode.get("variationType").asText());
+    @NotNull final Map<String, Variation> variations = deserializeVariations(jsonNode.get("variations"));
+    @NotNull final List<String> sortedVariationKeys = new ArrayList<>(variations.keySet());
+    Collections.sort(sortedVariationKeys);
+    @NotNull final List<Allocation> allocations = deserializeAllocations(jsonNode.get("allocations"));
 
-    return new FlagConfig(key, enabled, totalShards, variationType, variations, allocations);
+    return new FlagConfig(key, enabled, totalShards, variationType, variations, sortedVariationKeys, allocations);
   }
 
-  private Map<String, Variation> deserializeVariations(JsonNode jsonNode) {
-    Map<String, Variation> variations = new HashMap<>();
+  @NotNull
+  private Map<String, Variation> deserializeVariations(@Nullable JsonNode jsonNode) {
+    @NotNull final Map<String, Variation> variations = new HashMap<>();
     if (jsonNode == null) {
       return variations;
     }
-    for (Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields(); it.hasNext(); ) {
-      Map.Entry<String, JsonNode> entry = it.next();
-      String key = entry.getValue().get("key").asText();
-      EppoValue value = eppoValueDeserializer.deserializeNode(entry.getValue().get("value"));
+    for (@NotNull final Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields(); it.hasNext(); ) {
+      @NotNull final Map.Entry<String, JsonNode> entry = it.next();
+      @NotNull final String key = entry.getValue().get("key").asText();
+      @NotNull final EppoValue value = eppoValueDeserializer.deserializeNode(entry.getValue().get("value"));
       variations.put(entry.getKey(), new Variation(key, value));
     }
     return variations;
   }
 
-  private List<Allocation> deserializeAllocations(JsonNode jsonNode) {
-    List<Allocation> allocations = new ArrayList<>();
+  @NotNull
+  private List<Allocation> deserializeAllocations(@Nullable JsonNode jsonNode) {
+    @NotNull final List<Allocation> allocations = new ArrayList<>();
     if (jsonNode == null) {
       return allocations;
     }
-    for (JsonNode allocationNode : jsonNode) {
-      String key = allocationNode.get("key").asText();
-      Set<TargetingRule> rules = deserializeTargetingRules(allocationNode.get("rules"));
-      Date startAt = parseUtcISODateNode(allocationNode.get("startAt"));
-      Date endAt = parseUtcISODateNode(allocationNode.get("endAt"));
-      List<Split> splits = deserializeSplits(allocationNode.get("splits"));
+    for (@NotNull final JsonNode allocationNode : jsonNode) {
+      @NotNull final String key = allocationNode.get("key").asText();
+      @NotNull final Set<TargetingRule> rules = deserializeTargetingRules(allocationNode.get("rules"));
+      @Nullable final Date startAt = parseUtcISODateNode(allocationNode.get("startAt"));
+      @Nullable final Date endAt = parseUtcISODateNode(allocationNode.get("endAt"));
+      @NotNull final List<Split> splits = deserializeSplits(allocationNode.get("splits"));
       boolean doLog = allocationNode.get("doLog").asBoolean();
       allocations.add(new Allocation(key, rules, startAt, endAt, splits, doLog));
     }
     return allocations;
   }
 
-  private Set<TargetingRule> deserializeTargetingRules(JsonNode jsonNode) {
-    Set<TargetingRule> targetingRules = new HashSet<>();
+  @NotNull
+  private Set<TargetingRule> deserializeTargetingRules(@Nullable JsonNode jsonNode) {
+    @NotNull final Set<TargetingRule> targetingRules = new HashSet<>();
     if (jsonNode == null || !jsonNode.isArray()) {
       return targetingRules;
     }
-    for (JsonNode ruleNode : jsonNode) {
-      Set<TargetingCondition> conditions = new HashSet<>();
-      for (JsonNode conditionNode : ruleNode.get("conditions")) {
-        String attribute = conditionNode.get("attribute").asText();
-        String operatorKey = conditionNode.get("operator").asText();
-        OperatorType operator = OperatorType.fromString(operatorKey);
+    for (@NotNull final JsonNode ruleNode : jsonNode) {
+      @NotNull final Set<TargetingCondition> conditions = new HashSet<>();
+      for (@NotNull final JsonNode conditionNode : ruleNode.get("conditions")) {
+        @NotNull final String attribute = conditionNode.get("attribute").asText();
+        @NotNull final String operatorKey = conditionNode.get("operator").asText();
+        @Nullable final OperatorType operator = OperatorType.fromString(operatorKey);
         if (operator == null) {
           log.warn("Unknown operator \"{}\"", operatorKey);
           continue;
         }
-        EppoValue value = eppoValueDeserializer.deserializeNode(conditionNode.get("value"));
+        @NotNull final EppoValue value = eppoValueDeserializer.deserializeNode(conditionNode.get("value"));
         conditions.add(new TargetingCondition(operator, attribute, value));
       }
       targetingRules.add(new TargetingRule(conditions));
@@ -150,19 +159,20 @@ public class FlagConfigResponseDeserializer extends StdDeserializer<FlagConfigRe
     return targetingRules;
   }
 
-  private List<Split> deserializeSplits(JsonNode jsonNode) {
-    List<Split> splits = new ArrayList<>();
+  @NotNull
+  private List<Split> deserializeSplits(@Nullable JsonNode jsonNode) {
+    @NotNull final List<Split> splits = new ArrayList<>();
     if (jsonNode == null || !jsonNode.isArray()) {
       return splits;
     }
-    for (JsonNode splitNode : jsonNode) {
-      String variationKey = splitNode.get("variationKey").asText();
-      Set<Shard> shards = deserializeShards(splitNode.get("shards"));
-      Map<String, String> extraLogging = new HashMap<>();
-      JsonNode extraLoggingNode = splitNode.get("extraLogging");
+    for (@NotNull final JsonNode splitNode : jsonNode) {
+      @NotNull final String variationKey = splitNode.get("variationKey").asText();
+      @NotNull final Set<Shard> shards = deserializeShards(splitNode.get("shards"));
+      @NotNull final Map<String, String> extraLogging = new HashMap<>();
+      @Nullable final JsonNode extraLoggingNode = splitNode.get("extraLogging");
       if (extraLoggingNode != null && extraLoggingNode.isObject()) {
-        for (Iterator<Map.Entry<String, JsonNode>> it = extraLoggingNode.fields(); it.hasNext(); ) {
-          Map.Entry<String, JsonNode> entry = it.next();
+        for (@NotNull final Iterator<Map.Entry<String, JsonNode>> it = extraLoggingNode.fields(); it.hasNext(); ) {
+          @NotNull final Map.Entry<String, JsonNode> entry = it.next();
           extraLogging.put(entry.getKey(), entry.getValue().asText());
         }
       }
@@ -172,17 +182,18 @@ public class FlagConfigResponseDeserializer extends StdDeserializer<FlagConfigRe
     return splits;
   }
 
-  private Set<Shard> deserializeShards(JsonNode jsonNode) {
-    Set<Shard> shards = new HashSet<>();
+  @NotNull
+  private Set<Shard> deserializeShards(@Nullable JsonNode jsonNode) {
+    @NotNull final Set<Shard> shards = new HashSet<>();
     if (jsonNode == null || !jsonNode.isArray()) {
       return shards;
     }
-    for (JsonNode shardNode : jsonNode) {
-      String salt = shardNode.get("salt").asText();
-      Set<ShardRange> ranges = new HashSet<>();
-      for (JsonNode rangeNode : shardNode.get("ranges")) {
-        int start = rangeNode.get("start").asInt();
-        int end = rangeNode.get("end").asInt();
+    for (@NotNull final JsonNode shardNode : jsonNode) {
+      @NotNull final String salt = shardNode.get("salt").asText();
+      @NotNull final Set<ShardRange> ranges = new HashSet<>();
+      for (@NotNull final JsonNode rangeNode : shardNode.get("ranges")) {
+        final int start = rangeNode.get("start").asInt();
+        final int end = rangeNode.get("end").asInt();
         ranges.add(new ShardRange(start, end));
       }
       shards.add(new Shard(salt, ranges));
@@ -190,18 +201,19 @@ public class FlagConfigResponseDeserializer extends StdDeserializer<FlagConfigRe
     return shards;
   }
 
-  private BanditReference deserializeBanditReference(JsonNode jsonNode) {
-    String modelVersion = jsonNode.get("modelVersion").asText();
-    List<BanditFlagVariation> flagVariations = new ArrayList<>();
-    JsonNode flagVariationsNode = jsonNode.get("flagVariations");
+  @NotNull
+  private BanditReference deserializeBanditReference(@NotNull JsonNode jsonNode) {
+    @NotNull final String modelVersion = jsonNode.get("modelVersion").asText();
+    @NotNull final List<BanditFlagVariation> flagVariations = new ArrayList<>();
+    @Nullable final JsonNode flagVariationsNode = jsonNode.get("flagVariations");
     if (flagVariationsNode != null && flagVariationsNode.isArray()) {
-      for (JsonNode flagVariationNode : flagVariationsNode) {
-        String banditKey = flagVariationNode.get("key").asText();
-        String flagKey = flagVariationNode.get("flagKey").asText();
-        String allocationKey = flagVariationNode.get("allocationKey").asText();
-        String variationKey = flagVariationNode.get("variationKey").asText();
-        String variationValue = flagVariationNode.get("variationValue").asText();
-        BanditFlagVariation flagVariation =
+      for (@NotNull final JsonNode flagVariationNode : flagVariationsNode) {
+        @NotNull final String banditKey = flagVariationNode.get("key").asText();
+        @NotNull final String flagKey = flagVariationNode.get("flagKey").asText();
+        @NotNull final String allocationKey = flagVariationNode.get("allocationKey").asText();
+        @NotNull final String variationKey = flagVariationNode.get("variationKey").asText();
+        @NotNull final String variationValue = flagVariationNode.get("variationValue").asText();
+        @NotNull final BanditFlagVariation flagVariation =
             new BanditFlagVariation(
                 banditKey, flagKey, allocationKey, variationKey, variationValue);
         flagVariations.add(flagVariation);

--- a/src/test/java/cloud/eppo/api/ConfigurationBuilderTest.java
+++ b/src/test/java/cloud/eppo/api/ConfigurationBuilderTest.java
@@ -68,6 +68,7 @@ public class ConfigurationBuilderTest {
             1,
             VariationType.STRING,
             Collections.emptyMap(),
+            Collections.emptyList(),
             Collections.emptyList());
 
     // Create configuration with this flag
@@ -92,6 +93,7 @@ public class ConfigurationBuilderTest {
             1,
             VariationType.NUMERIC,
             Collections.emptyMap(),
+            Collections.emptyList(),
             Collections.emptyList());
 
     // Create configuration with this flag using MD5 hash of the flag key


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
When evaluating a feature flag, I want to know if the evaluation failed and why. We report the state of all of our feature flags into Crashlytics as we evaluate them, and if a feature flag failed to load, we want to update its state accordingly.

## Description
Added minimum nullability necessary to add required fields. Also added `sortedVariationKeys` to `FlagConfig` to make finding the variation index cheaper.

If you strongly oppose the nullability annotations, I can remove them, but it made reasoning about the code much simpler, and I found a couple of missing null checks because of them.

## How has this been documented?
Added documentation to new classes.

## How has this been tested?
Added unit tests. Not sure how to unit test no allocations inside `BaseEppoClientTest`
