### PR TITLE
Revert "chore(deps): bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.1.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,13 @@ java {
 dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.0'
   implementation 'com.github.zafarkhaja:java-semver:0.10.2'
-  implementation "com.squareup.okhttp3:okhttp:5.1.0"
+  implementation "com.squareup.okhttp3:okhttp:4.12.0"
   // For LRU and expiring maps
   implementation 'org.apache.commons:commons-collections4:4.5.0'
   implementation 'org.slf4j:slf4j-api:2.0.17'
   testImplementation 'org.slf4j:slf4j-simple:2.0.17'
   testImplementation platform('org.junit:junit-bom:5.11.4')
-  testImplementation("com.squareup.okhttp3:mockwebserver:5.1.0")
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.skyscreamer:jsonassert:1.5.3'
   testImplementation 'commons-io:commons-io:2.20.0'


### PR DESCRIPTION
Reverts Eppo-exp/sdk-common-jdk#139
per request from customer
Also OkHTTP has separate Android and JVM artifacts now, so it isn’t appropriate to share a single implementation between JVM and Android