### PR TITLE
Use transitive dependency for framework instead of source bundling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ group = 'cloud.eppo'
 version = '0.1.0-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
+// Set base archives name to match published artifactId so Gradle can resolve project(':') references
+base {
+  archivesName.set('eppo-sdk-framework')
+}
+
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8

--- a/eppo-sdk-common/build.gradle
+++ b/eppo-sdk-common/build.gradle
@@ -1,8 +1,8 @@
 plugins {
   id 'java-library'
   id 'maven-publish'
-  id "com.diffplug.spotless" version "6.13.0"
 }
+apply plugin: 'com.diffplug.spotless'
 
 group = 'cloud.eppo'
 version = '4.0.0-SNAPSHOT'
@@ -10,36 +10,27 @@ version = '4.0.0-SNAPSHOT'
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
+  withSourcesJar()
+  withJavadocJar()
 }
 
-// Create a combined JAR that includes both this module and the framework
-jar {
-  // Include classes from the root framework module
-  from(project(':').sourceSets.main.output)
-  // This module's classes take precedence over framework classes
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+// Include root (framework) sources in this module so we compile one codebase — no project dependency
+sourceSets {
+  main {
+    java.srcDirs project(':').file('src/main/java'), 'src/main/java'
+    resources.srcDirs project(':').file('src/main/resources'), 'src/main/resources'
+  }
 }
 
-// Create combined sources JAR
-tasks.register('sourcesJar', Jar) {
-  archiveClassifier.set('sources')
-  from sourceSets.main.allSource
-  from project(':').sourceSets.main.allSource
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
-// Create combined javadoc JAR
-tasks.register('javadocJar', Jar) {
-  archiveClassifier.set('javadoc')
-  from javadoc
-  from project(':').tasks.javadoc
-
-  // Temporary fix until the clean-up is down and jackson parsing is removed from the framework.
+tasks.named('sourcesJar', Jar).configure {
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 dependencies {
-  api project(':')
+  // Framework dependencies (from root) — needed to compile the inlined framework sources
+  api 'org.jetbrains:annotations:26.0.1'
+  implementation 'com.github.zafarkhaja:java-semver:0.10.2'
+  implementation 'org.apache.commons:commons-collections4:4.5.0'
 
   implementation 'com.squareup.okhttp3:okhttp:4.12.0'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
@@ -76,6 +67,7 @@ spotless {
     endWithNewline()
   }
   java {
+    target 'src/main/java/**/*.java'  // only this module's sources; framework lives under root
     googleJavaFormat('1.7')
     formatAnnotations()
   }
@@ -97,8 +89,6 @@ publishing {
       artifactId = 'sdk-common-jvm'
 
       from components.java
-      artifact sourcesJar
-      artifact javadocJar
 
       pom {
         name = 'Eppo SDK Common JVM'
@@ -121,13 +111,6 @@ publishing {
           developerConnection = 'scm:git:ssh://github.com/Eppo-exp/sdk-common-jvm.git'
           url = 'https://github.com/Eppo-exp/sdk-common-jvm'
         }
-      }
-
-      // Remove the framework dependency from POM since it's bundled in the JAR
-      pom.withXml {
-        asNode().dependencies.dependency.findAll {
-          it.artifactId.text() == 'eppo-sdk-framework'
-        }.each { it.parent().remove(it) }
       }
     }
   }

--- a/eppo-sdk-common/build.gradle
+++ b/eppo-sdk-common/build.gradle
@@ -1,8 +1,8 @@
 plugins {
   id 'java-library'
   id 'maven-publish'
+  id 'com.diffplug.spotless' version '6.13.0'
 }
-apply plugin: 'com.diffplug.spotless'
 
 group = 'cloud.eppo'
 version = '4.0.0-SNAPSHOT'
@@ -54,7 +54,6 @@ spotless {
     endWithNewline()
   }
   java {
-    target 'src/main/java/**/*.java'
     googleJavaFormat('1.7')
     formatAnnotations()
   }
@@ -108,10 +107,12 @@ publishing {
           url = 'https://github.com/Eppo-exp/sdk-common-jvm'
         }
 
-        // Explicitly add framework dependency to POM (Gradle module metadata includes it automatically)
+        // Add framework dependency to POM for Maven consumers
+        // Gradle includes 'api project(':')' in .module metadata but not in .pom
+        // This is necessary because Gradle can't auto-map the root project to its published coordinates
         withXml {
           def dependenciesNode = asNode().dependencies[0]
-          if (dependenciesNode) {
+          if (!dependenciesNode.dependency.find { it.artifactId.text() == 'eppo-sdk-framework' }) {
             def frameworkDep = dependenciesNode.appendNode('dependency')
             frameworkDep.appendNode('groupId', 'cloud.eppo')
             frameworkDep.appendNode('artifactId', 'eppo-sdk-framework')

--- a/eppo-sdk-common/build.gradle
+++ b/eppo-sdk-common/build.gradle
@@ -107,9 +107,9 @@ publishing {
           url = 'https://github.com/Eppo-exp/sdk-common-jvm'
         }
 
-        // Add framework dependency to POM for Maven consumers
-        // Gradle limitation: 'api project(':')' is included in .module metadata but not in .pom
-        // Root project references cannot be auto-mapped to Maven coordinates in POM generation
+        // Manual POM manipulation required for Maven consumers
+        // Gradle module metadata correctly includes the dependency, but POMs don't
+        // Root project references (project(':')) aren't translated to Maven coordinates in POM generation
         // See: https://github.com/gradle/gradle/issues/16784
         withXml {
           def dependenciesNode = asNode().dependencies[0]

--- a/eppo-sdk-common/build.gradle
+++ b/eppo-sdk-common/build.gradle
@@ -14,24 +14,11 @@ java {
   withJavadocJar()
 }
 
-// Include root (framework) sources in this module so we compile one codebase — no project dependency
-sourceSets {
-  main {
-    java.srcDirs project(':').file('src/main/java'), 'src/main/java'
-    resources.srcDirs project(':').file('src/main/resources'), 'src/main/resources'
-  }
-}
-
-tasks.named('sourcesJar', Jar).configure {
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
 dependencies {
-  // Framework dependencies (from root) — needed to compile the inlined framework sources
-  api 'org.jetbrains:annotations:26.0.1'
-  implementation 'com.github.zafarkhaja:java-semver:0.10.2'
-  implementation 'org.apache.commons:commons-collections4:4.5.0'
+  // Framework dependency - provides core interfaces and logic
+  api project(':')
 
+  // HTTP client and JSON parser implementations
   implementation 'com.squareup.okhttp3:okhttp:4.12.0'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
 
@@ -67,7 +54,7 @@ spotless {
     endWithNewline()
   }
   java {
-    target 'src/main/java/**/*.java'  // only this module's sources; framework lives under root
+    target 'src/main/java/**/*.java'
     googleJavaFormat('1.7')
     formatAnnotations()
   }
@@ -90,6 +77,15 @@ publishing {
 
       from components.java
 
+      versionMapping {
+        usage('java-api') {
+          fromResolutionOf('runtimeClasspath')
+        }
+        usage('java-runtime') {
+          fromResolutionResult()
+        }
+      }
+
       pom {
         name = 'Eppo SDK Common JVM'
         description = 'Complete Eppo SDK for JVM with default HTTP client and configuration parser'
@@ -110,6 +106,18 @@ publishing {
           connection = 'scm:git:git://github.com/Eppo-exp/sdk-common-jvm.git'
           developerConnection = 'scm:git:ssh://github.com/Eppo-exp/sdk-common-jvm.git'
           url = 'https://github.com/Eppo-exp/sdk-common-jvm'
+        }
+
+        // Explicitly add framework dependency to POM (Gradle module metadata includes it automatically)
+        withXml {
+          def dependenciesNode = asNode().dependencies[0]
+          if (dependenciesNode) {
+            def frameworkDep = dependenciesNode.appendNode('dependency')
+            frameworkDep.appendNode('groupId', 'cloud.eppo')
+            frameworkDep.appendNode('artifactId', 'eppo-sdk-framework')
+            frameworkDep.appendNode('version', project(':').version)
+            frameworkDep.appendNode('scope', 'compile')
+          }
         }
       }
     }

--- a/eppo-sdk-common/build.gradle
+++ b/eppo-sdk-common/build.gradle
@@ -108,8 +108,9 @@ publishing {
         }
 
         // Add framework dependency to POM for Maven consumers
-        // Gradle includes 'api project(':')' in .module metadata but not in .pom
-        // This is necessary because Gradle can't auto-map the root project to its published coordinates
+        // Gradle limitation: 'api project(':')' is included in .module metadata but not in .pom
+        // Root project references cannot be auto-mapped to Maven coordinates in POM generation
+        // See: https://github.com/gradle/gradle/issues/16784
         withXml {
           def dependenciesNode = asNode().dependencies[0]
           if (!dependenciesNode.dependency.find { it.artifactId.text() == 'eppo-sdk-framework' }) {


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

The `eppo-sdk-common` module previously inlined the framework sources by adding them to its own sourceSets and compiling everything together. This approach worked but was architecturally unconventional - it obscured the dependency relationship and required custom build configuration.

This change uses standard Gradle transitive dependencies instead, making the framework a proper `api` dependency of the common module.

## Description
[//]: # (Describe your changes in detail)

- **Add framework as transitive dependency**: Use `api project(':')` instead of source inlining
- **Remove source inlining**: Delete custom `sourceSets` configuration that added framework sources
- **Remove duplicate framework dependencies**: Framework libs (annotations, java-semver, commons-collections4) now inherited transitively
- **Add version mapping**: Configure dependency resolution for proper published metadata
- **Fix root project configuration**: Add `archivesName.set('eppo-sdk-framework')` to resolve mismatch between `rootProject.name` and published artifactId
- **Fix POM generation**: Add explicit `withXml` configuration to ensure framework dependency appears in Maven POM (required due to Gradle limitation with root project references - see [gradle/gradle#16784](https://github.com/gradle/gradle/issues/16784))

### Why the withXml workaround is needed

We investigated whether proper Gradle configuration could eliminate the need for manual POM manipulation. Findings:
- Root cause: Gradle doesn't automatically translate `api project(':')` to Maven coordinates in POMs for root project references
- With `archivesName` configured: Gradle module metadata (.module files) works correctly
- Without `withXml` block: Maven POMs missing the framework dependency
- This is a confirmed Gradle limitation, not a configuration issue

## Benefits

- **Standard Gradle approach**: Uses normal transitive dependencies like any other library
- **Cleaner architecture**: Each module compiles independently with explicit dependencies
- **Proper module separation**: Framework remains a distinct published artifact
- **Better Gradle support**: Module metadata now correctly includes dependencies automatically
- **Maven compatibility**: POM includes all necessary dependencies via withXml workaround

## Versioning Strategy

The framework and sdk-common are versioned independently:
- Framework: `0.1.0-SNAPSHOT` (newly extracted)
- SDK Common: `4.0.0-SNAPSHOT` (established module)

This allows each to evolve at its own pace.

## Consumer Impact

**Not a breaking change.** From a consumer perspective:
- Still declare dependency on `cloud.eppo:sdk-common-jvm:4.0.0-SNAPSHOT`
- Maven/Gradle automatically resolves `eppo-sdk-framework` as a transitive dependency
- No changes required to consuming projects
- Both artifacts published to the same repository (Maven Central)

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

No separate docs needed; this is an internal build change. Consumer API is unchanged - sdk-common-jvm still pulls in all the same dependencies via standard transitive dependency resolution.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

- `./gradlew :eppo-sdk-common:build` passes with all tests passing
- Verified generated Gradle module metadata includes framework dependency automatically
- Verified generated Maven POM includes framework dependency with correct coordinates via withXml
- Tested that removing withXml block causes framework dependency to be missing from POM (confirming it's necessary)
- Published to mavenLocal and verified both artifacts are present with correct dependency relationships