### PR TITLE
chore: release versions for common 4.0.0 and framework 0.1.0

### DIFF
--- a/FRAMEWORK_SDK_GUIDE.md
+++ b/FRAMEWORK_SDK_GUIDE.md
@@ -1,0 +1,870 @@
+# Eppo SDK Framework Guide
+
+This guide explains how to use the `eppo-sdk-framework` artifact to implement custom HTTP clients and configuration parsers.
+
+**Use this guide if:**
+- You need a custom JSON library (e.g., Gson, Moshi instead of Jackson)
+- You have custom networking requirements (custom SSL, proxies, authentication)
+- You're on a platform where OkHttp or Jackson aren't suitable (e.g., GraalVM native image)
+
+**Don't use this guide if:**
+- You can use the standard `sdk-common-jvm` artifact (it includes ready-to-use implementations)
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Artifact Configuration](#artifact-configuration)
+3. [Implementing ConfigurationParser](#implementing-configurationparser)
+4. [Implementing EppoConfigurationClient](#implementing-eppoconfigurationclient)
+5. [Complete Example: Gson Implementation](#complete-example-gson-implementation)
+6. [Testing Your Implementation](#testing-your-implementation)
+7. [Reference: sdk-common-jvm Source](#reference-sdk-common-jvm-source)
+
+---
+
+## Overview
+
+The framework provides two interfaces you must implement:
+
+| Interface | Purpose | Input | Output |
+|-----------|---------|-------|--------|
+| `ConfigurationParser<JSONFlagType>` | Parse JSON bytes to DTOs | Raw JSON bytes | Parsed DTO objects |
+| `EppoConfigurationClient` | Fetch configuration from API | Request object | Response with bytes |
+
+### Architecture
+
+```
+┌──────────────────────┐
+│  Your Application    │
+└──────────┬───────────┘
+           │
+    ┌──────▼────────┐
+    │ BaseEppoClient│
+    └──────┬────────┘
+           │
+           ├─────────────────┐
+           │                 │
+    ┌──────▼──────────┐ ┌───▼─────────────────┐
+    │  Your Parser    │ │  Your HTTP Client    │
+    │  Implementation │ │  Implementation      │
+    └─────────────────┘ └──────────────────────┘
+```
+
+---
+
+## Artifact Configuration
+
+### Gradle
+
+```groovy
+dependencies {
+    implementation 'cloud.eppo:eppo-sdk-framework:0.1.0'
+
+    // Add your choice of JSON library
+    implementation 'com.google.code.gson:gson:2.10.1'  // Example
+
+    // Add your choice of HTTP library
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'  // Example
+}
+
+repositories {
+    mavenCentral()
+}
+```
+
+### Maven
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>cloud.eppo</groupId>
+        <artifactId>eppo-sdk-framework</artifactId>
+        <version>0.1.0</version>
+    </dependency>
+
+    <!-- Add your JSON library -->
+    <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.10.1</version>
+    </dependency>
+
+    <!-- Add your HTTP library -->
+    <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>4.12.0</version>
+    </dependency>
+</dependencies>
+
+```
+
+---
+
+## Implementing ConfigurationParser
+
+### Interface Definition
+
+```java
+package cloud.eppo.parser;
+
+import cloud.eppo.api.dto.BanditParametersResponse;
+import cloud.eppo.api.dto.FlagConfigResponse;
+import org.jetbrains.annotations.NotNull;
+
+public interface ConfigurationParser<JSONFlagType> {
+
+  /**
+   * Parse raw flag configuration JSON bytes.
+   */
+  @NotNull FlagConfigResponse parseFlagConfig(@NotNull byte[] flagConfigJson)
+      throws ConfigurationParseException;
+
+  /**
+   * Parse raw bandit parameters JSON bytes.
+   */
+  @NotNull BanditParametersResponse parseBanditParams(@NotNull byte[] banditParamsJson)
+      throws ConfigurationParseException;
+
+  /**
+   * Parse a JSON value string to your JSON library's type.
+   */
+  @NotNull JSONFlagType parseJsonValue(@NotNull String jsonValue)
+      throws ConfigurationParseException;
+}
+```
+
+### Implementation Template
+
+```java
+package com.example;
+
+import cloud.eppo.api.dto.*;
+import cloud.eppo.parser.ConfigurationParser;
+import cloud.eppo.parser.ConfigurationParseException;
+import org.jetbrains.annotations.NotNull;
+
+public class MyConfigurationParser implements ConfigurationParser<YourJsonType> {
+
+    @Override
+    @NotNull public FlagConfigResponse parseFlagConfig(@NotNull byte[] flagConfigJson)
+            throws ConfigurationParseException {
+        try {
+            // 1. Parse JSON bytes to your library's object model
+            YourJsonObject root = yourLibrary.parse(flagConfigJson);
+
+            // 2. Extract flags map
+            Map<String, FlagConfig> flags = parseFlags(root.get("flags"));
+
+            // 3. Extract bandit references map
+            Map<String, BanditReference> banditReferences =
+                parseBanditReferences(root.get("bandits"));
+
+            // 4. Extract format
+            FlagConfigResponse.Format format = parseFormat(root.get("format"));
+
+            // 5. Extract metadata
+            String environmentName = root.getString("environment", null);
+            Date createdAt = parseDate(root.get("createdAt"));
+
+            // 6. Return FlagConfigResponse implementation
+            return new FlagConfigResponse.Default(
+                flags,
+                banditReferences,
+                format,
+                environmentName,
+                createdAt
+            );
+
+        } catch (Exception e) {
+            throw new ConfigurationParseException(
+                "Failed to parse flag configuration", e);
+        }
+    }
+
+    @Override
+    @NotNull public BanditParametersResponse parseBanditParams(@NotNull byte[] banditParamsJson)
+            throws ConfigurationParseException {
+        try {
+            // 1. Parse JSON bytes
+            YourJsonObject root = yourLibrary.parse(banditParamsJson);
+
+            // 2. Extract bandits map
+            Map<String, BanditParameters> bandits = parseBandits(root.get("bandits"));
+
+            // 3. Return BanditParametersResponse implementation
+            return new BanditParametersResponse.Default(bandits);
+
+        } catch (Exception e) {
+            throw new ConfigurationParseException(
+                "Failed to parse bandit parameters", e);
+        }
+    }
+
+    @Override
+    @NotNull public YourJsonType parseJsonValue(@NotNull String jsonValue)
+            throws ConfigurationParseException {
+        try {
+            return yourLibrary.parse(jsonValue);
+        } catch (Exception e) {
+            throw new ConfigurationParseException(
+                "Failed to parse JSON value", e);
+        }
+    }
+
+    // Helper methods to parse nested objects...
+    private Map<String, FlagConfig> parseFlags(YourJsonObject flagsObj) {
+        // Parse each flag to FlagConfig.Default
+    }
+
+    private Map<String, BanditReference> parseBanditReferences(YourJsonObject banditsObj) {
+        // Parse each bandit reference to BanditReference.Default
+    }
+}
+```
+
+### Key Points
+
+1. **Use Default Implementations:** All DTOs have nested `Default` classes you should instantiate
+2. **Handle Nulls:** Many DTO fields are nullable - check the DTO interface definitions
+3. **Date Parsing:** Dates are in ISO 8601 format (e.g., "2024-01-15T10:30:00Z")
+4. **Format Enum:** `FlagConfigResponse.Format` has two values: `SERVER` and `CLIENT`
+5. **Error Handling:** Wrap all exceptions in `ConfigurationParseException`
+
+### DTO Interfaces Reference
+
+All DTOs follow this pattern:
+
+```java
+public interface FlagConfig extends Serializable {
+    @NotNull String getKey();
+    boolean isEnabled();
+    int getTotalShards();
+    @NotNull VariationType getVariationType();
+    @NotNull Map<String, Variation> getVariations();
+    @NotNull List<Allocation> getAllocations();
+
+    class Default implements FlagConfig {
+        // Constructor and implementation
+    }
+}
+```
+
+See `src/main/java/cloud/eppo/api/dto/` for all DTO definitions.
+
+---
+
+## Implementing EppoConfigurationClient
+
+### Interface Definition
+
+```java
+package cloud.eppo.http;
+
+import java.util.concurrent.CompletableFuture;
+import org.jetbrains.annotations.NotNull;
+
+public interface EppoConfigurationClient {
+  /**
+   * Executes a configuration request asynchronously.
+   *
+   * The request may be either GET or POST based on request.getMethod().
+   * For synchronous behavior, use .get() or .join() on the returned CompletableFuture.
+   */
+  @NotNull CompletableFuture<EppoConfigurationResponse> execute(
+      @NotNull EppoConfigurationRequest request);
+}
+```
+
+### Request Object
+
+```java
+public class EppoConfigurationRequest {
+    @NotNull public String getBaseUrl();         // e.g., "https://fscdn.eppo.cloud"
+    @NotNull public String getResourcePath();    // e.g., "/api/flag-config/v1/config"
+    @NotNull public Map<String, String> getQueryParams();  // apiKey, sdkName, sdkVersion
+    @Nullable public String getLastVersionId();  // For conditional requests (If-None-Match)
+    @NotNull public HttpMethod getMethod();      // GET or POST
+    @Nullable public byte[] getBody();           // Request body for POST requests
+    @Nullable public String getContentType();    // Content type for POST requests
+}
+```
+
+### Response Object
+
+```java
+public class EppoConfigurationResponse {
+    public int getStatusCode();           // HTTP status code
+    @Nullable public String getVersionId();  // ETag value from response
+    @Nullable public byte[] getBody();       // Response body (null for 304)
+
+    public boolean isSuccessful();        // true if 2xx
+    public boolean isNotModified();       // true if 304
+
+    // Factory methods
+    public static EppoConfigurationResponse success(int statusCode, String versionId, byte[] body);
+    public static EppoConfigurationResponse notModified(String versionId);
+    public static EppoConfigurationResponse error(int statusCode, byte[] body);
+}
+```
+
+### Implementation Template
+
+```java
+package com.example;
+
+import cloud.eppo.http.*;
+import java.util.concurrent.CompletableFuture;
+import org.jetbrains.annotations.NotNull;
+
+public class MyHttpClient implements EppoConfigurationClient {
+
+    @Override
+    @NotNull public CompletableFuture<EppoConfigurationResponse> execute(
+            @NotNull EppoConfigurationRequest request) {
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                // 1. Build full URL from request
+                String url = buildUrl(request);
+
+                // 2. Create HTTP request
+                YourHttpRequest httpRequest = yourLibrary.newRequest()
+                    .url(url)
+                    .get();
+
+                // 3. Add If-None-Match header if version ID present
+                if (request.getLastVersionId() != null) {
+                    httpRequest.addHeader("If-None-Match", request.getLastVersionId());
+                }
+
+                // 4. Execute request
+                YourHttpResponse httpResponse = httpRequest.execute();
+
+                // 5. Extract ETag from response headers
+                String versionId = httpResponse.getHeader("ETag");
+
+                // 6. Handle different status codes
+                int statusCode = httpResponse.getStatusCode();
+
+                if (statusCode == 304) {
+                    // Not Modified
+                    return EppoConfigurationResponse.notModified(versionId);
+
+                } else if (statusCode >= 200 && statusCode < 300) {
+                    // Success
+                    byte[] body = httpResponse.getBodyBytes();
+                    return EppoConfigurationResponse.success(statusCode, versionId, body);
+
+                } else {
+                    // Error
+                    byte[] body = httpResponse.getBodyBytes();
+                    return EppoConfigurationResponse.error(statusCode, body);
+                }
+
+            } catch (Exception e) {
+                // Return error response on exception
+                return EppoConfigurationResponse.error(500, null);
+            }
+        });
+    }
+
+    private String buildUrl(EppoConfigurationRequest request) {
+        StringBuilder url = new StringBuilder();
+        url.append(request.getBaseUrl());
+        url.append(request.getResourcePath());
+
+        // Add query parameters
+        boolean first = true;
+        for (Map.Entry<String, String> param : request.getQueryParams().entrySet()) {
+            url.append(first ? "?" : "&");
+            url.append(urlEncode(param.getKey()));
+            url.append("=");
+            url.append(urlEncode(param.getValue()));
+            first = false;
+        }
+
+        return url.toString();
+    }
+
+    private String urlEncode(String value) {
+        // Use URLEncoder.encode or your HTTP library's method
+    }
+}
+```
+
+### Key Points
+
+1. **Asynchronous:** Return `CompletableFuture` - SDK will handle blocking if needed
+2. **ETag Support:** Extract `ETag` header and return as `versionId`
+3. **If-None-Match:** Send `lastVersionId` as `If-None-Match` header for conditional requests
+4. **304 Handling:** Return `notModified()` response with null body
+5. **Error Handling:** Catch exceptions and return error response
+6. **Timeouts:** Configure appropriate connection and read timeouts
+7. **POST Support:** Check `request.getMethod()` — for POST requests, include `request.getBody()` and `request.getContentType()`
+
+---
+
+## Complete Example: Gson Implementation
+
+Here's a complete working example using Gson for JSON and OkHttp for HTTP.
+
+### 1. Parser Implementation
+
+```java
+package com.example.eppo;
+
+import cloud.eppo.api.dto.*;
+import cloud.eppo.parser.ConfigurationParser;
+import cloud.eppo.parser.ConfigurationParseException;
+import com.google.gson.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+public class GsonConfigurationParser implements ConfigurationParser<JsonElement> {
+
+    private final Gson gson = new GsonBuilder()
+        .setDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        .create();
+
+    @Override
+    @NotNull public FlagConfigResponse parseFlagConfig(@NotNull byte[] flagConfigJson)
+            throws ConfigurationParseException {
+        try {
+            String jsonStr = new String(flagConfigJson, StandardCharsets.UTF_8);
+            JsonObject root = JsonParser.parseString(jsonStr).getAsJsonObject();
+
+            // Parse flags
+            Map<String, FlagConfig> flags = new HashMap<>();
+            if (root.has("flags")) {
+                JsonObject flagsObj = root.getAsJsonObject("flags");
+                for (Map.Entry<String, JsonElement> entry : flagsObj.entrySet()) {
+                    flags.put(entry.getKey(), parseFlagConfig(entry.getValue().getAsJsonObject()));
+                }
+            }
+
+            // Parse bandit references
+            Map<String, BanditReference> banditRefs = new HashMap<>();
+            if (root.has("bandits")) {
+                JsonObject banditsObj = root.getAsJsonObject("bandits");
+                for (Map.Entry<String, JsonElement> entry : banditsObj.entrySet()) {
+                    banditRefs.put(entry.getKey(), parseBanditReference(entry.getValue().getAsJsonObject()));
+                }
+            }
+
+            // Parse format
+            FlagConfigResponse.Format format = FlagConfigResponse.Format.SERVER;
+            if (root.has("format")) {
+                format = FlagConfigResponse.Format.valueOf(root.get("format").getAsString());
+            }
+
+            // Parse metadata
+            String environmentName = root.has("environment") ? root.get("environment").getAsString() : null;
+            Date createdAt = root.has("createdAt") ? parseDate(root.get("createdAt").getAsString()) : null;
+
+            return new FlagConfigResponse.Default(flags, banditRefs, format, environmentName, createdAt);
+
+        } catch (Exception e) {
+            throw new ConfigurationParseException("Failed to parse flag configuration", e);
+        }
+    }
+
+    @Override
+    @NotNull public BanditParametersResponse parseBanditParams(@NotNull byte[] banditParamsJson)
+            throws ConfigurationParseException {
+        try {
+            String jsonStr = new String(banditParamsJson, StandardCharsets.UTF_8);
+            JsonObject root = JsonParser.parseString(jsonStr).getAsJsonObject();
+
+            Map<String, BanditParameters> bandits = new HashMap<>();
+            if (root.has("bandits")) {
+                JsonObject banditsObj = root.getAsJsonObject("bandits");
+                for (Map.Entry<String, JsonElement> entry : banditsObj.entrySet()) {
+                    bandits.put(entry.getKey(), parseBanditParameters(entry.getValue().getAsJsonObject()));
+                }
+            }
+
+            return new BanditParametersResponse.Default(bandits);
+
+        } catch (Exception e) {
+            throw new ConfigurationParseException("Failed to parse bandit parameters", e);
+        }
+    }
+
+    @Override
+    @NotNull public JsonElement parseJsonValue(@NotNull String jsonValue)
+            throws ConfigurationParseException {
+        try {
+            return JsonParser.parseString(jsonValue);
+        } catch (Exception e) {
+            throw new ConfigurationParseException("Failed to parse JSON value", e);
+        }
+    }
+
+    // Helper methods...
+    private FlagConfig parseFlagConfig(JsonObject obj) {
+        String key = obj.get("key").getAsString();
+        boolean enabled = obj.get("enabled").getAsBoolean();
+        int totalShards = obj.get("totalShards").getAsInt();
+        VariationType variationType = VariationType.valueOf(obj.get("variationType").getAsString());
+
+        Map<String, Variation> variations = new HashMap<>();
+        // Parse variations...
+
+        List<Allocation> allocations = new ArrayList<>();
+        // Parse allocations...
+
+        return new FlagConfig.Default(key, enabled, totalShards, variationType, variations, allocations);
+    }
+
+    private Date parseDate(String dateStr) throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.parse(dateStr);
+    }
+
+    // Additional helper methods for parsing other DTOs...
+}
+```
+
+### 2. HTTP Client Implementation
+
+```java
+package com.example.eppo;
+
+import cloud.eppo.http.*;
+import okhttp3.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class CustomOkHttpClient implements EppoConfigurationClient {
+
+    private final OkHttpClient client;
+
+    public CustomOkHttpClient() {
+        this.client = new OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build();
+    }
+
+    @Override
+    @NotNull public CompletableFuture<EppoConfigurationResponse> execute(
+            @NotNull EppoConfigurationRequest request) {
+
+        CompletableFuture<EppoConfigurationResponse> future = new CompletableFuture<>();
+
+        // Build URL
+        HttpUrl.Builder urlBuilder = HttpUrl.parse(
+            request.getBaseUrl() + request.getResourcePath()
+        ).newBuilder();
+
+        for (Map.Entry<String, String> param : request.getQueryParams().entrySet()) {
+            urlBuilder.addQueryParameter(param.getKey(), param.getValue());
+        }
+
+        // Build request
+        Request.Builder reqBuilder = new Request.Builder()
+            .url(urlBuilder.build())
+            .get();
+
+        // Add If-None-Match header if present
+        if (request.getLastVersionId() != null) {
+            reqBuilder.addHeader("If-None-Match", request.getLastVersionId());
+        }
+
+        // Execute asynchronously
+        client.newCall(reqBuilder.build()).enqueue(new Callback() {
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try {
+                    String etag = response.header("ETag");
+                    int statusCode = response.code();
+
+                    if (statusCode == 304) {
+                        future.complete(EppoConfigurationResponse.notModified(etag));
+
+                    } else if (response.isSuccessful() && response.body() != null) {
+                        byte[] body = response.body().bytes();
+                        future.complete(EppoConfigurationResponse.success(statusCode, etag, body));
+
+                    } else {
+                        byte[] body = response.body() != null ? response.body().bytes() : null;
+                        future.complete(EppoConfigurationResponse.error(statusCode, body));
+                    }
+
+                } catch (IOException e) {
+                    future.complete(EppoConfigurationResponse.error(500, null));
+                } finally {
+                    response.close();
+                }
+            }
+
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                future.complete(EppoConfigurationResponse.error(500, null));
+            }
+        });
+
+        return future;
+    }
+}
+```
+
+### 3. Usage
+
+```java
+package com.example;
+
+import cloud.eppo.BaseEppoClient;
+import com.example.eppo.GsonConfigurationParser;
+import com.example.eppo.CustomOkHttpClient;
+import com.google.gson.JsonElement;
+
+public class MyEppoClient extends BaseEppoClient<JsonElement> {
+
+    public MyEppoClient(String apiKey) {
+        super(
+            apiKey,
+            "my-sdk",
+            "1.0.0",
+            null,   // apiBaseUrl
+            null,   // assignmentLogger
+            null,   // banditLogger
+            null,   // configurationStore
+            false,  // isGracefulMode
+            false,  // expectObfuscatedConfig
+            true,   // supportBandits
+            null,   // initialConfiguration
+            null,   // assignmentCache
+            null,   // banditAssignmentCache
+            new GsonConfigurationParser(),  // Your parser
+            new CustomOkHttpClient()        // Your HTTP client
+        );
+    }
+
+    // Your client methods...
+}
+```
+
+---
+
+## Testing Your Implementation
+
+### Unit Tests
+
+```java
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class GsonConfigurationParserTest {
+
+    @Test
+    public void testParseFlagConfig() throws Exception {
+        GsonConfigurationParser parser = new GsonConfigurationParser();
+
+        String json = "{ \"flags\": {}, \"format\": \"SERVER\" }";
+        FlagConfigResponse response = parser.parseFlagConfig(json.getBytes());
+
+        assertNotNull(response);
+        assertEquals(FlagConfigResponse.Format.SERVER, response.getFormat());
+        assertTrue(response.getFlags().isEmpty());
+    }
+
+    @Test
+    public void testParseJsonValue() throws Exception {
+        GsonConfigurationParser parser = new GsonConfigurationParser();
+
+        JsonElement element = parser.parseJsonValue("{\"key\": \"value\"}");
+
+        assertTrue(element.isJsonObject());
+        assertEquals("value", element.getAsJsonObject().get("key").getAsString());
+    }
+}
+```
+
+### Integration Tests
+
+```java
+import org.junit.Test;
+import com.squareup.okhttp3.mockwebserver.MockWebServer;
+import com.squareup.okhttp3.mockwebserver.MockResponse;
+
+public class CustomOkHttpClientTest {
+
+    @Test
+    public void testSuccessfulRequest() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+
+        server.enqueue(new MockResponse()
+            .setResponseCode(200)
+            .setHeader("ETag", "version123")
+            .setBody("{\"flags\": {}}"));
+
+        CustomOkHttpClient client = new CustomOkHttpClient();
+        EppoConfigurationRequestFactory factory = new EppoConfigurationRequestFactory(
+            server.url("/").toString(), "apiKey", "test", "1.0");
+
+        EppoConfigurationRequest request = factory.createFlagConfigRequest(null);
+        EppoConfigurationResponse response = client.execute(request).get();
+
+        assertTrue(response.isSuccessful());
+        assertEquals("version123", response.getVersionId());
+        assertNotNull(response.getBody());
+
+        server.shutdown();
+    }
+
+    @Test
+    public void testNotModifiedResponse() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+
+        server.enqueue(new MockResponse()
+            .setResponseCode(304)
+            .setHeader("ETag", "version123"));
+
+        CustomOkHttpClient client = new CustomOkHttpClient();
+        EppoConfigurationRequestFactory factory = new EppoConfigurationRequestFactory(
+            server.url("/").toString(), "apiKey", "test", "1.0");
+
+        EppoConfigurationRequest request = factory.createFlagConfigRequest("version123");
+        EppoConfigurationResponse response = client.execute(request).get();
+
+        assertTrue(response.isNotModified());
+        assertEquals("version123", response.getVersionId());
+        assertNull(response.getBody());
+
+        server.shutdown();
+    }
+}
+```
+
+---
+
+## Reference: sdk-common-jvm Source
+
+The `eppo-sdk-common` module contains reference implementations:
+
+### JacksonConfigurationParser
+
+Location: `eppo-sdk-common/src/main/java/cloud/eppo/JacksonConfigurationParser.java`
+
+Shows how to:
+- Use Jackson to parse configuration JSON
+- Handle all DTO types
+- Deal with null/optional fields
+- Parse dates in ISO 8601 format
+
+### OkHttpEppoClient
+
+Location: `eppo-sdk-common/src/main/java/cloud/eppo/OkHttpEppoClient.java`
+
+Shows how to:
+- Use OkHttp for async requests
+- Handle ETags and conditional requests
+- Build URLs from request objects
+- Handle different response codes
+
+### JSON Deserializers
+
+Location: `eppo-sdk-common/src/main/java/cloud/eppo/ufc/dto/adapters/`
+
+Contains Jackson custom deserializers for:
+- `FlagConfigResponse`
+- `BanditParametersResponse`
+- Date handling
+- EppoValue serialization
+
+---
+
+## Common Pitfalls
+
+### 1. Not Handling Nulls
+
+Many DTO fields are nullable. Always check before accessing:
+
+```java
+// ❌ BAD
+String env = flagConfigResponse.getEnvironmentName().toLowerCase();
+
+// ✅ GOOD
+String env = flagConfigResponse.getEnvironmentName();
+if (env != null) {
+    env = env.toLowerCase();
+}
+```
+
+### 2. Incorrect Date Format
+
+Dates must be parsed as ISO 8601 with UTC timezone:
+
+```java
+SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+Date date = sdf.parse(dateString);
+```
+
+### 3. Not Using Default Implementations
+
+Always use the nested `Default` classes when creating DTOs:
+
+```java
+// ❌ BAD - interface not instantiable
+FlagConfig config = new FlagConfig(...);
+
+// ✅ GOOD - use nested Default class
+FlagConfig config = new FlagConfig.Default(...);
+```
+
+### 4. Blocking on CompletableFuture
+
+Don't block the calling thread in the HTTP client implementation:
+
+```java
+// ❌ BAD - blocks in async method
+public CompletableFuture<EppoConfigurationResponse> execute(EppoConfigurationRequest request) {
+    Response response = httpClient.send(request);  // Blocking!
+    return CompletableFuture.completedFuture(parseResponse(response));
+}
+
+// ✅ GOOD - truly async
+public CompletableFuture<EppoConfigurationResponse> execute(EppoConfigurationRequest request) {
+    return CompletableFuture.supplyAsync(() -> {
+        Response response = httpClient.execute(request);
+        return parseResponse(response);
+    });
+}
+```
+
+### 5. Not Handling 304 Correctly
+
+304 Not Modified responses have no body:
+
+```java
+if (statusCode == 304) {
+    return EppoConfigurationResponse.notModified(versionId);  // body is null
+} else if (statusCode == 200) {
+    return EppoConfigurationResponse.success(statusCode, versionId, body);
+}
+```
+
+---
+
+## Support
+
+- **Framework Source:** https://github.com/Eppo-exp/sdk-common-jdk
+- **Reference Implementation:** See `eppo-sdk-common/` directory
+- **Issues:** https://github.com/Eppo-exp/sdk-common-jdk/issues
+- **Migration Guide:** See `MIGRATION_GUIDE_v4.md` for upgrading from v3.x

--- a/FRAMEWORK_SDK_GUIDE.md
+++ b/FRAMEWORK_SDK_GUIDE.md
@@ -160,13 +160,16 @@ public class MyConfigurationParser implements ConfigurationParser<YourJsonType> 
 
             // 3. Extract bandit references map
             Map<String, BanditReference> banditReferences =
-                parseBanditReferences(root.get("bandits"));
+                parseBanditReferences(root.get("banditReferences"));
 
             // 4. Extract format
             FlagConfigResponse.Format format = parseFormat(root.get("format"));
 
             // 5. Extract metadata
-            String environmentName = root.getString("environment", null);
+            // "environment" is an object with a "name" field, not a plain string
+            String environmentName = root.hasObject("environment")
+                ? root.getObject("environment").getString("name", null)
+                : null;
             Date createdAt = parseDate(root.get("createdAt"));
 
             // 6. Return FlagConfigResponse implementation
@@ -219,8 +222,10 @@ public class MyConfigurationParser implements ConfigurationParser<YourJsonType> 
         // Parse each flag to FlagConfig.Default
     }
 
-    private Map<String, BanditReference> parseBanditReferences(YourJsonObject banditsObj) {
+    private Map<String, BanditReference> parseBanditReferences(YourJsonObject banditRefsObj) {
         // Parse each bandit reference to BanditReference.Default
+        // Each entry has: modelVersion (string), flagVariations (array of objects)
+        // Each flagVariation has: key, flagKey, allocationKey, variationKey, variationValue
     }
 }
 ```
@@ -430,7 +435,7 @@ import java.util.*;
 public class GsonConfigurationParser implements ConfigurationParser<JsonElement> {
 
     private final Gson gson = new GsonBuilder()
-        .setDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         .create();
 
     @Override
@@ -451,9 +456,9 @@ public class GsonConfigurationParser implements ConfigurationParser<JsonElement>
 
             // Parse bandit references
             Map<String, BanditReference> banditRefs = new HashMap<>();
-            if (root.has("bandits")) {
-                JsonObject banditsObj = root.getAsJsonObject("bandits");
-                for (Map.Entry<String, JsonElement> entry : banditsObj.entrySet()) {
+            if (root.has("banditReferences")) {
+                JsonObject banditRefsObj = root.getAsJsonObject("banditReferences");
+                for (Map.Entry<String, JsonElement> entry : banditRefsObj.entrySet()) {
                     banditRefs.put(entry.getKey(), parseBanditReference(entry.getValue().getAsJsonObject()));
                 }
             }
@@ -465,7 +470,12 @@ public class GsonConfigurationParser implements ConfigurationParser<JsonElement>
             }
 
             // Parse metadata
-            String environmentName = root.has("environment") ? root.get("environment").getAsString() : null;
+            // "environment" is an object with a "name" field, not a plain string
+            String environmentName = null;
+            if (root.has("environment") && root.get("environment").isJsonObject()) {
+                JsonObject envObj = root.getAsJsonObject("environment");
+                environmentName = envObj.has("name") ? envObj.get("name").getAsString() : null;
+            }
             Date createdAt = root.has("createdAt") ? parseDate(root.get("createdAt").getAsString()) : null;
 
             return new FlagConfigResponse.Default(flags, banditRefs, format, environmentName, createdAt);
@@ -524,7 +534,7 @@ public class GsonConfigurationParser implements ConfigurationParser<JsonElement>
     }
 
     private Date parseDate(String dateStr) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         return sdf.parse(dateStr);
     }
@@ -811,7 +821,7 @@ if (env != null) {
 Dates must be parsed as ISO 8601 with UTC timezone:
 
 ```java
-SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
 sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 Date date = sdf.parse(dateString);
 ```

--- a/MIGRATION_GUIDE_v4.md
+++ b/MIGRATION_GUIDE_v4.md
@@ -1,0 +1,637 @@
+# Eppo SDK v4.0 Migration Guide
+
+This guide documents all breaking changes when upgrading from v3.x to v4.0. It is designed for both human developers and coding agents performing automated migrations.
+
+**Last Updated:** Generated from snapshot/v4 branch comparison against main
+
+---
+
+## Table of Contents
+
+1. [Artifacts Overview](#artifacts-overview)
+2. [Package Relocations](#package-relocations)
+3. [DTOs Converted to Interfaces](#dtos-converted-to-interfaces)
+4. [Removed Classes](#removed-classes)
+5. [New Pluggable Interfaces](#new-pluggable-interfaces)
+6. [Configuration.Builder Changes](#configurationbuilder-changes)
+7. [BaseEppoClient Changes](#baseeppoclient-changes)
+8. [EppoValue.unwrap() Changes](#eppovalueunwrap-changes)
+9. [HTTP Abstraction Layer](#http-abstraction-layer)
+10. [Utils.Base64Codec](#utilsbase64codec)
+11. [Quick Migration Checklist](#quick-migration-checklist)
+12. [Complete Examples](#complete-examples)
+
+---
+
+## Artifacts Overview
+
+### v3.x Structure
+- Single artifact: `cloud.eppo:eppo-sdk-framework` (used for all implementations)
+- All HTTP and parsing logic embedded in framework
+
+### v4.0 Structure
+
+Two artifacts with different purposes:
+
+| Artifact | Version | Description | When to Use |
+|----------|---------|-------------|-------------|
+| `cloud.eppo:sdk-common-jvm` | `4.0.0` | **Batteries-included SDK** with OkHttp client and Jackson parser | Most users - ready to use out of box |
+| `cloud.eppo:eppo-sdk-framework` | `0.1.0` | **Core framework** with interfaces only | Custom implementations (different JSON library, custom networking) |
+
+**Recommendation:** Use `sdk-common-jvm` unless you have specific requirements for custom HTTP or JSON handling.
+
+---
+
+## Package Relocations
+
+All DTO classes moved from `cloud.eppo.ufc.dto` to `cloud.eppo.api.dto`.
+
+### Find and Replace
+
+```bash
+# Automated replacement
+sed -i 's/cloud\.eppo\.ufc\.dto/cloud.eppo.api.dto/g' **/*.java **/*.kt
+```
+
+### Affected Classes
+
+All of these classes require import updates:
+
+```
+cloud.eppo.ufc.dto.Allocation                           → cloud.eppo.api.dto.Allocation
+cloud.eppo.ufc.dto.BanditAttributeCoefficients          → cloud.eppo.api.dto.BanditAttributeCoefficients
+cloud.eppo.ufc.dto.BanditCategoricalAttributeCoefficients → cloud.eppo.api.dto.BanditCategoricalAttributeCoefficients
+cloud.eppo.ufc.dto.BanditCoefficients                   → cloud.eppo.api.dto.BanditCoefficients
+cloud.eppo.ufc.dto.BanditFlagVariation                  → cloud.eppo.api.dto.BanditFlagVariation
+cloud.eppo.ufc.dto.BanditModelData                      → cloud.eppo.api.dto.BanditModelData
+cloud.eppo.ufc.dto.BanditNumericAttributeCoefficients   → cloud.eppo.api.dto.BanditNumericAttributeCoefficients
+cloud.eppo.ufc.dto.BanditParameters                     → cloud.eppo.api.dto.BanditParameters
+cloud.eppo.ufc.dto.BanditParametersResponse             → cloud.eppo.api.dto.BanditParametersResponse
+cloud.eppo.ufc.dto.BanditReference                      → cloud.eppo.api.dto.BanditReference
+cloud.eppo.ufc.dto.EppoValueType                        → cloud.eppo.api.dto.EppoValueType
+cloud.eppo.ufc.dto.FlagConfig                           → cloud.eppo.api.dto.FlagConfig
+cloud.eppo.ufc.dto.FlagConfigResponse                   → cloud.eppo.api.dto.FlagConfigResponse
+cloud.eppo.ufc.dto.OperatorType                         → cloud.eppo.api.dto.OperatorType
+cloud.eppo.ufc.dto.Shard                                → cloud.eppo.api.dto.Shard
+cloud.eppo.ufc.dto.Split                                → cloud.eppo.api.dto.Split
+cloud.eppo.ufc.dto.TargetingCondition                   → cloud.eppo.api.dto.TargetingCondition
+cloud.eppo.ufc.dto.TargetingRule                        → cloud.eppo.api.dto.TargetingRule
+cloud.eppo.ufc.dto.Variation                            → cloud.eppo.api.dto.Variation
+cloud.eppo.ufc.dto.VariationType                        → cloud.eppo.api.dto.VariationType
+```
+
+---
+
+## DTOs Converted to Interfaces
+
+Major DTOs converted from concrete classes to interfaces with nested `Default` implementations.
+
+### Affected Types
+
+All of these are now interfaces:
+- `Allocation`
+- `BanditAttributeCoefficients`
+- `BanditCategoricalAttributeCoefficients`
+- `BanditCoefficients`
+- `BanditFlagVariation`
+- `BanditModelData`
+- `BanditNumericAttributeCoefficients`
+- `BanditParameters`
+- `BanditParametersResponse`
+- `BanditReference`
+- `FlagConfig`
+- `FlagConfigResponse`
+- `Shard`
+- `Split`
+- `TargetingCondition`
+- `TargetingRule`
+- `Variation`
+
+### Migration Pattern
+
+```java
+// v3.x - Direct instantiation
+FlagConfig config = new FlagConfig(key, enabled, shards, type, variations, allocations);
+FlagConfigResponse response = new FlagConfigResponse(flags, refs, format, env, created);
+
+// v4.0 - Use nested Default class
+FlagConfig config = new FlagConfig.Default(key, enabled, shards, type, variations, allocations);
+FlagConfigResponse response = new FlagConfigResponse.Default(flags, refs, format, env, created);
+```
+
+**Note:** If you only use these types as method parameters or return types (not direct instantiation), no code changes are needed.
+
+---
+
+## Removed Classes
+
+### `cloud.eppo.EppoHttpClient` - REMOVED
+
+The built-in HTTP client has been removed from the framework.
+
+**Migration:**
+- **If using `sdk-common-jvm`:** No action needed - `OkHttpEppoClient` is provided
+- **If using framework only:** Implement `EppoConfigurationClient` interface
+
+### `cloud.eppo.EppoHttpClientRequestCallback` - REMOVED
+
+Callback interface replaced by `CompletableFuture` pattern in new `EppoConfigurationClient`.
+
+### Removed Methods
+
+| Class | Removed Method | Replacement |
+|-------|----------------|-------------|
+| `Configuration` | `serializeFlagConfigToBytes()` | Store parsed DTOs or use parser directly |
+| `Configuration` | `serializeBanditParamsToBytes()` | Store parsed DTOs or use parser directly |
+| `Attributes` | `serializeNonNullAttributesToJSONString()` | Implement your own serialization |
+
+---
+
+## New Pluggable Interfaces
+
+### `ConfigurationParser<JSONFlagType>`
+
+Interface for parsing configuration JSON. Decouples JSON library choice from framework.
+
+```java
+public interface ConfigurationParser<JSONFlagType> {
+  FlagConfigResponse parseFlagConfig(byte[] flagConfigJson) throws ConfigurationParseException;
+  BanditParametersResponse parseBanditParams(byte[] banditParamsJson) throws ConfigurationParseException;
+  JSONFlagType parseJsonValue(String jsonValue) throws ConfigurationParseException;
+}
+```
+
+**Default implementation (sdk-common-jvm):** `JacksonConfigurationParser`
+
+**Usage:**
+```java
+// Using the default Jackson implementation
+ConfigurationParser<JsonNode> parser = new JacksonConfigurationParser();
+FlagConfigResponse flagConfig = parser.parseFlagConfig(jsonBytes);
+```
+
+### `EppoConfigurationClient`
+
+Interface for HTTP operations. Allows custom HTTP implementations.
+
+```java
+public interface EppoConfigurationClient {
+  CompletableFuture<EppoConfigurationResponse> execute(EppoConfigurationRequest request);
+}
+```
+
+**Default implementation (sdk-common-jvm):** `OkHttpEppoClient`
+
+**Usage:**
+```java
+// Using the default OkHttp implementation
+EppoConfigurationClient client = new OkHttpEppoClient();
+```
+
+### When Do You Need These?
+
+| Artifact Used | Need to Implement? |
+|---------------|-------------------|
+| `sdk-common-jvm` | ❌ No - defaults provided |
+| `eppo-sdk-framework` | ✅ Yes - must implement both |
+
+---
+
+## Configuration.Builder Changes
+
+The builder no longer accepts raw JSON bytes. It now requires pre-parsed objects.
+
+### v3.x API
+
+```java
+// Takes raw JSON bytes
+Configuration config = new Configuration.Builder(flagConfigJsonBytes)
+    .banditParameters(banditParamsJsonBytes)  // byte[] or String
+    .build();
+```
+
+### v4.0 API
+
+```java
+// Takes parsed objects
+ConfigurationParser<JsonNode> parser = new JacksonConfigurationParser();
+FlagConfigResponse flagConfig = parser.parseFlagConfig(flagConfigJsonBytes);
+BanditParametersResponse banditParams = parser.parseBanditParams(banditParamsJsonBytes);
+
+Configuration config = new Configuration.Builder(flagConfig)
+    .banditParameters(banditParams)
+    .flagsSnapshotId(versionId)  // NEW: for caching/ETags
+    .build();
+```
+
+### Method Changes
+
+| v3.x | v4.0 | Notes |
+|------|------|-------|
+| `Builder(byte[] flagJson)` | `Builder(FlagConfigResponse)` | Must parse first |
+| `banditParameters(byte[] json)` | `banditParameters(BanditParametersResponse)` | Must parse first |
+| `banditParameters(String json)` | `banditParameters(BanditParametersResponse)` | Must parse first |
+| `requiresBanditModels()` | `requiresUpdatedBanditModels()` | Renamed |
+| N/A | `flagsSnapshotId(String)` | NEW: ETag support |
+
+### New Feature: Snapshot IDs
+
+Configuration now tracks version IDs (ETags) for conditional requests:
+
+```java
+Configuration config = builder.flagsSnapshotId(response.getVersionId()).build();
+String snapshotId = config.getFlagsSnapshotId();  // For subsequent requests
+```
+
+---
+
+## BaseEppoClient Changes
+
+The client is now generic and requires two new dependencies.
+
+### Class Declaration
+
+```java
+// v3.x
+public class MyClient extends BaseEppoClient { }
+
+// v4.0 - Add type parameter for JSON library
+public class MyClient extends BaseEppoClient<JsonNode> { }  // Jackson
+public class MyClient extends BaseEppoClient<JsonElement> { }  // Gson
+```
+
+### Constructor Changes
+
+```java
+// v3.x - 13 parameters
+protected BaseEppoClient(
+    String apiKey,
+    String sdkName,
+    String sdkVersion,
+    String apiBaseUrl,
+    AssignmentLogger assignmentLogger,
+    BanditLogger banditLogger,
+    IConfigurationStore configurationStore,
+    boolean isGracefulMode,
+    boolean expectObfuscatedConfig,
+    boolean supportBandits,
+    CompletableFuture<Configuration> initialConfiguration,
+    IAssignmentCache assignmentCache,
+    IAssignmentCache banditAssignmentCache)
+
+// v4.0 - 15 parameters (added 2)
+protected BaseEppoClient<JsonFlagType>(
+    String apiKey,
+    String sdkName,
+    String sdkVersion,
+    String apiBaseUrl,
+    AssignmentLogger assignmentLogger,
+    BanditLogger banditLogger,
+    IConfigurationStore configurationStore,
+    boolean isGracefulMode,
+    boolean expectObfuscatedConfig,
+    boolean supportBandits,
+    CompletableFuture<Configuration> initialConfiguration,
+    IAssignmentCache assignmentCache,
+    IAssignmentCache banditAssignmentCache,
+    ConfigurationParser<JsonFlagType> configurationParser,  // NEW
+    EppoConfigurationClient configurationClient)            // NEW
+```
+
+### JSON Assignment Methods
+
+Return type changed from `JsonNode` to generic `JsonFlagType`:
+
+```java
+// v3.x
+JsonNode getJSONAssignment(String flagKey, String subjectKey, JsonNode defaultValue);
+
+// v4.0
+JsonFlagType getJSONAssignment(String flagKey, String subjectKey, JsonFlagType defaultValue);
+```
+
+### Migration Example
+
+```java
+// v3.x
+public class MyClient extends BaseEppoClient {
+    public MyClient(String apiKey) {
+        super(apiKey, "my-sdk", "1.0", null, null, null, null, false, false, true, null, null, null);
+    }
+}
+
+// v4.0
+public class MyClient extends BaseEppoClient<JsonNode> {
+    public MyClient(String apiKey) {
+        super(
+            apiKey, "my-sdk", "1.0",
+            null, null, null, null,
+            false, false, true, null, null, null,
+            new JacksonConfigurationParser(),  // NEW
+            new OkHttpEppoClient()              // NEW
+        );
+    }
+}
+```
+
+---
+
+## EppoValue.unwrap() Changes
+
+JSON unwrapping now requires an explicit parser function.
+
+### v3.x API
+
+```java
+// All types including JSON worked with single method
+Boolean bool = eppoValue.unwrap(VariationType.BOOLEAN);
+String str = eppoValue.unwrap(VariationType.STRING);
+JsonNode json = eppoValue.unwrap(VariationType.JSON);  // Used Jackson internally
+```
+
+### v4.0 API
+
+```java
+// Non-JSON types unchanged
+Boolean bool = eppoValue.unwrap(VariationType.BOOLEAN);
+Integer num = eppoValue.unwrap(VariationType.INTEGER);
+Double dbl = eppoValue.unwrap(VariationType.NUMERIC);
+String str = eppoValue.unwrap(VariationType.STRING);
+
+// JSON requires parser function
+JsonNode json = eppoValue.unwrap(VariationType.JSON, parser::parseJsonValue);
+
+// Or with lambda
+JsonNode json = eppoValue.unwrap(VariationType.JSON, jsonStr -> {
+    try {
+        return new ObjectMapper().readTree(jsonStr);
+    } catch (Exception e) {
+        return null;
+    }
+});
+
+// Calling without parser throws exception
+eppoValue.unwrap(VariationType.JSON);  // ❌ IllegalArgumentException
+```
+
+### Method Signatures
+
+```java
+// Existing method - throws for JSON type
+public <T> T unwrap(VariationType expectedType)
+
+// New overload - required for JSON
+public <T> T unwrap(VariationType expectedType, Function<String, ?> jsonParser)
+```
+
+---
+
+## HTTP Abstraction Layer
+
+New package `cloud.eppo.http` provides clean HTTP abstractions.
+
+### Core Classes
+
+| Class | Purpose |
+|-------|---------|
+| `EppoConfigurationClient` | Interface for HTTP operations (single `execute()` method) |
+| `EppoConfigurationRequest` | Immutable request (URL, params, version ID, method, body) |
+| `EppoConfigurationResponse` | Immutable response (status, version ID, body) |
+| `EppoConfigurationRequestFactory` | Creates typed requests for flags/bandits |
+
+### Request/Response Flow
+
+```java
+// 1. Create factory with SDK info
+EppoConfigurationRequestFactory factory = new EppoConfigurationRequestFactory(
+    baseUrl, apiKey, sdkName, sdkVersion);
+
+// 2. Create request (with conditional fetch support)
+EppoConfigurationRequest request = factory.createFlagConfigRequest(lastVersionId);
+
+// 3. Execute via client
+EppoConfigurationClient client = new OkHttpEppoClient();
+CompletableFuture<EppoConfigurationResponse> future = client.execute(request);
+
+// 4. Handle response
+EppoConfigurationResponse response = future.get();
+if (response.isSuccessful()) {
+    byte[] body = response.getBody();
+    String newVersionId = response.getVersionId();  // Save for next request
+} else if (response.isNotModified()) {
+    // 304 Not Modified - use cached config
+}
+```
+
+### Conditional Requests (304 Not Modified)
+
+v4.0 supports efficient caching via ETags:
+
+```java
+// First request
+String lastVersionId = null;
+EppoConfigurationRequest req1 = factory.createFlagConfigRequest(lastVersionId);
+EppoConfigurationResponse res1 = client.execute(req1).get();
+lastVersionId = res1.getVersionId();  // Save ETag
+
+// Subsequent request - may return 304
+EppoConfigurationRequest req2 = factory.createFlagConfigRequest(lastVersionId);
+EppoConfigurationResponse res2 = client.execute(req2).get();
+if (res2.isNotModified()) {
+    // No changes, use cached configuration
+}
+```
+
+---
+
+## Utils.Base64Codec
+
+New pluggable interface for Base64 operations (useful for Android).
+
+```java
+public interface Base64Codec {
+    String base64Encode(String input);
+    String base64Decode(String input);
+}
+```
+
+### Default Behavior
+
+Uses `java.util.Base64` by default.
+
+### Custom Implementation
+
+```java
+// Set custom codec (e.g., android.util.Base64)
+Utils.setBase64Codec(new Utils.Base64Codec() {
+    @Override
+    public String base64Encode(String input) {
+        return android.util.Base64.encodeToString(
+            input.getBytes(StandardCharsets.UTF_8),
+            android.util.Base64.NO_WRAP);
+    }
+
+    @Override
+    public String base64Decode(String input) {
+        return new String(
+            android.util.Base64.decode(input, android.util.Base64.NO_WRAP),
+            StandardCharsets.UTF_8);
+    }
+});
+```
+
+---
+
+## Quick Migration Checklist
+
+### All Users
+
+- [ ] Update dependency: `sdk-common-jvm:4.0.0` (replaces `eppo-sdk-framework`)
+- [ ] Update imports: `cloud.eppo.ufc.dto.*` → `cloud.eppo.api.dto.*`
+- [ ] Replace DTO instantiation: `new FlagConfig(...)` → `new FlagConfig.Default(...)`
+- [ ] Update Configuration.Builder: pass parsed `FlagConfigResponse` instead of `byte[]`
+- [ ] Update JSON unwrap: `unwrap(JSON)` → `unwrap(JSON, parser::parseJsonValue)`
+- [ ] Remove calls to removed methods: `serializeFlagConfigToBytes()`, etc.
+
+### If Extending BaseEppoClient
+
+- [ ] Add generic type parameter: `BaseEppoClient<JsonNode>`
+- [ ] Add `ConfigurationParser` to constructor
+- [ ] Add `EppoConfigurationClient` to constructor
+
+### If Using Framework Only (Advanced)
+
+- [ ] Implement `ConfigurationParser<YourJsonType>`
+- [ ] Implement `EppoConfigurationClient`
+
+---
+
+## Complete Examples
+
+### Basic Usage (sdk-common-jvm)
+
+```java
+// v3.x
+import cloud.eppo.ufc.dto.FlagConfig;
+import cloud.eppo.api.Configuration;
+
+byte[] jsonBytes = fetchConfigJson();
+Configuration config = new Configuration.Builder(jsonBytes).build();
+
+// v4.0
+import cloud.eppo.api.dto.FlagConfig;
+import cloud.eppo.api.dto.FlagConfigResponse;
+import cloud.eppo.api.Configuration;
+import cloud.eppo.JacksonConfigurationParser;
+import cloud.eppo.parser.ConfigurationParser;
+import com.fasterxml.jackson.databind.JsonNode;
+
+ConfigurationParser<JsonNode> parser = new JacksonConfigurationParser();
+byte[] jsonBytes = fetchConfigJson();
+FlagConfigResponse flagConfig = parser.parseFlagConfig(jsonBytes);
+Configuration config = new Configuration.Builder(flagConfig).build();
+```
+
+### Client Implementation
+
+```java
+// v3.x
+import cloud.eppo.BaseEppoClient;
+import cloud.eppo.ufc.dto.VariationType;
+
+public class MyEppoClient extends BaseEppoClient {
+    public MyEppoClient(String apiKey) {
+        super(apiKey, "my-sdk", "1.0.0", null, null, null, null, false, false, true, null, null, null);
+    }
+}
+
+// v4.0
+import cloud.eppo.BaseEppoClient;
+import cloud.eppo.JacksonConfigurationParser;
+import cloud.eppo.OkHttpEppoClient;
+import cloud.eppo.api.dto.VariationType;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class MyEppoClient extends BaseEppoClient<JsonNode> {
+    public MyEppoClient(String apiKey) {
+        super(
+            apiKey, "my-sdk", "1.0.0",
+            null, null, null, null, false, false, true, null, null, null,
+            new JacksonConfigurationParser(),
+            new OkHttpEppoClient()
+        );
+    }
+}
+```
+
+### JSON Flag Handling
+
+```java
+// v3.x
+JsonNode json = eppoValue.unwrap(VariationType.JSON);
+
+// v4.0
+ConfigurationParser<JsonNode> parser = new JacksonConfigurationParser();
+JsonNode json = eppoValue.unwrap(VariationType.JSON, parser::parseJsonValue);
+```
+
+---
+
+## Dependency Configuration
+
+### Using sdk-common-jvm (Recommended)
+
+```groovy
+// build.gradle
+dependencies {
+    implementation 'cloud.eppo:sdk-common-jvm:4.0.0'
+}
+
+repositories {
+    mavenCentral()
+}
+```
+
+Includes:
+- `JacksonConfigurationParser` (Jackson-based)
+- `OkHttpEppoClient` (OkHttp-based)
+- All transitive dependencies
+- **No custom implementations needed**
+
+### Using Framework Only (Advanced)
+
+```groovy
+// build.gradle
+dependencies {
+    implementation 'cloud.eppo:eppo-sdk-framework:0.1.0'
+}
+
+repositories {
+    mavenCentral()
+}
+```
+
+You must implement:
+- `ConfigurationParser<YourJsonType>`
+- `EppoConfigurationClient`
+
+---
+
+## Architecture Benefits
+
+v4.0 provides significant architectural improvements:
+
+1. **Separation of Concerns:** Core framework separate from HTTP/parsing implementations
+2. **Reduced Dependencies:** Framework no longer depends on Jackson or OkHttp
+3. **Pluggable Architecture:** Easy to swap HTTP clients or JSON libraries
+4. **Better Testing:** Interfaces make mocking and testing easier
+5. **Caching Support:** Built-in ETag/conditional request support
+6. **Platform Flexibility:** Easier to adapt for Android, GraalVM, etc.
+
+---
+
+## Need Help?
+
+- **Documentation:** See `FRAMEWORK_SDK_GUIDE.md` for implementing custom parsers/clients
+- **Issues:** https://github.com/Eppo-exp/sdk-common-jdk/issues
+- **Examples:** Check `eppo-sdk-common` module for reference implementations

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,11 @@ test-data:
 .PHONY: test
 test: test-data build
 	./gradlew check --no-daemon
+
+## snapshot-release - Push current branch to snapshot/<branch> to trigger snapshot publish workflow.
+.PHONY: snapshot-release
+snapshot-release:
+	$(eval LOCAL_BRANCH := $(shell git rev-parse --abbrev-ref HEAD))
+	@echo "$(INFO)Pushing $(LOCAL_BRANCH) to snapshot/$(LOCAL_BRANCH)$(END)"
+	git push origin HEAD:refs/heads/snapshot/$(LOCAL_BRANCH)
+	@echo "$(OK)Snapshot workflow triggered for snapshot/$(LOCAL_BRANCH)$(END)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ or [JVM](https://github.com/Eppo-exp/java-server-sdk) SDKs.
 
 ```groovy
 dependencies {
-  implementation 'cloud.eppo:sdk-common-jvm:3.13.1'
+  implementation 'cloud.eppo:sdk-common-jvm:4.0.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
 apply plugin: "com.diffplug.spotless"
 
 group = 'cloud.eppo'
-version = '0.1.0-SNAPSHOT'
+version = '0.1.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 // Set base archives name to match published artifactId so Gradle can resolve project(':') references

--- a/eppo-sdk-common/build.gradle
+++ b/eppo-sdk-common/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply plugin: "com.diffplug.spotless"
 
 group = 'cloud.eppo'
-version = '4.0.0-SNAPSHOT'
+version = '4.0.0'
 
 java {
   sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Summary

- Bumps `eppo-sdk-common` from `4.0.0-SNAPSHOT` → `4.0.0`
- Bumps `eppo-sdk-framework` from `0.1.0-SNAPSHOT` → `0.1.0`
- Updates README usage example from `3.13.1` → `4.0.0`
- Removes snapshot Maven repository references from release dependency examples in `MIGRATION_GUIDE_v4.md` and `FRAMEWORK_SDK_GUIDE.md`
- Adds `MIGRATION_GUIDE_v4.md` and `FRAMEWORK_SDK_GUIDE.md` to the repo
- Adds `snapshot-release` Makefile target for triggering snapshot publish workflows

## Test plan

- [ ] Verify `./gradlew build` passes
- [ ] Verify `ext.isReleaseVersion` evaluates to `true` for both modules
- [ ] Verify no SNAPSHOT version strings remain in consumer-facing documentation